### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,14 +6,20 @@
   "test_pattern": ".*[.]test[.]ts$",
   "exercises": [
     {
+      "uuid": "755f6f85-9ab3-4af6-9e35-dbb9d64be9c5",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings"
       ]
     },
     {
+      "uuid": "fb80f76c-42da-4f62-9f0f-8c85d984908b",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "math",
@@ -21,35 +27,50 @@
       ]
     },
     {
+      "uuid": "b4db381f-1c99-44c6-948c-c8892d77823e",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
 
       ]
     },
     {
+      "uuid": "18204e23-fca8-44dc-8d5c-abe66b87c640",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "9dfabc5c-d2a5-4896-9fc2-2b25b9a5f62f",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a2c7abe7-b487-4cc2-a86a-d97cdd61709d",
       "slug": "pangram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "8fe1e0ef-068e-4a53-a576-35be59f8152f",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "pattern matching",
@@ -57,28 +78,40 @@
       ]
     },
     {
+      "uuid": "3f649490-dc7d-4a77-a2a0-2ae71ae834a9",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "7c60f7c5-2922-4ce4-acbe-51c5ab654b4d",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "c8677318-ba6c-4e8c-83ec-513cc6530e7f",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "3977d4e5-82ca-4801-ae20-6682dda23506",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "control flow",
@@ -86,78 +119,105 @@
       ]
     },
     {
+      "uuid": "5e5c48fb-91bb-495a-97f6-ec8642739a0a",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "bbd4665c-be4b-4d70-bc92-e91ce7a1d55f",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "b00dd1af-f89c-4382-ab43-514651de6b20",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "7a4fefd2-6e71-42d6-82fd-a25d2ef9eae9",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "32e79fd7-f002-4bdc-b6bd-7a91d8c1af61",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "ab027a47-d483-4011-aac4-564a6284e5b8",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "269577e5-e782-4264-9ad9-9ad4b8bc0aab",
       "slug": "wordy",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "8e7b92f4-a508-4200-bd62-b36281dd9ed9",
       "slug": "say",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "pattern matching"
       ]
     },
     {
+      "uuid": "2ceec21e-fb9d-4145-8788-826c3941eb01",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
 
       ]
     },
     {
+      "uuid": "246129c9-83b5-43e0-beb6-8a2cea7e4e17",
       "slug": "food-chain",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
 
       ]
     }
-  ],
-  "deprecated": [
-
   ],
   "foregone": [
 


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16