### PR TITLE
Add default maintainers file

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,5 @@
 {
-  "slug": "typescript",
   "language": "TypeScript",
-  "repository": "https://github.com/exercism/typescript",
   "active": true,
   "test_pattern": ".*[.]test[.]ts$",
   "exercises": [

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -1,0 +1,25 @@
+{
+  "maintainers": [
+    {
+      "github_username": "masters3d",
+      "show_on_website": false,
+      "alumnus": false,
+      "name": null,
+      "bio": null,
+      "link_text": null,
+      "link_url": null,
+      "avatar_url": null
+    },
+    {
+      "github_username": "dsudia",
+      "show_on_website": false,
+      "alumnus": false,
+      "name": null,
+      "bio": null,
+      "link_text": null,
+      "link_url": null,
+      "avatar_url": null
+    }
+  ],
+  "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md"
+}


### PR DESCRIPTION
We wish to feature the maintainers of each track on the new (nextercism) website. Ideally, the bios will be tailored to each track, giving a friendly view into each maintainer's background and interest in the language, and even (perhaps) what they enjoy most about maintaining the track, or what type of things they tend to focus on.

The main reasons for including these are to:

* provide a stronger basis for empathy with maintainers
* give well-deserved recognition
* plant a seed in people's minds that _Exercism tracks are maintained by people like me... I could do that!_

Being featured on the Exercism website is entirely optional, and we're generating all the data with show_on_website=false so that if you don't want to bother, you don't have to change anything.

If you've moved on, or decide to do so, please submit and merge a PR (for visibility to the others involved) that sets **alumnus** to _true_ for your maintainer entry. I'm working on a bot that will update the GitHub team to reflect the current state of this file.

We can merge this as is, and any changes can be added in subsequent pull requests.

See https://github.com/exercism/meta/issues/20

FYI @masters3d, @dsudia - you are in the maintainer team for this track.