### PR TITLE
Explicitly tell configlet which track it is linting for Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: bin/fetch-configlet
-      - run: bin/configlet lint .
+      - run: bin/configlet lint . --track-id=typescript
       - run: make test
 
 workflows:


### PR DESCRIPTION
The Mac build on Circle CI appears to build the project into a directory with a non-standard name,
'project', which means that the configlet lint command tells the Exercism UUID API endpoint that
it's checking the UUIDs of the 'project' track, rather than the typescript track.

As a result, the UUID API reports that the UUIDs are duplicates.

By explicitly telling the API which track is being linted, it doesn't mistakenly report duplicates.