### PR TITLE
Add auto_approve to hello-world exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
       "slug": "hello-world",
       "uuid": "755f6f85-9ab3-4af6-9e35-dbb9d64be9c5",
       "core": true,
+      "auto_approve": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [


### PR DESCRIPTION
This adds the auto_approve property to the hello-world 
exercise as part of preparing tracks for the v2 launch.

The current code on the server will automatically approve
hello-world exercises anyway, but that is a temporary fix
and will be removed in the future.

See exercism/typescript#202