### PR TITLE
fix callback type in accumulate.test.ts test

### DIFF
--- a/exercises/accumulate/accumulate.test.ts
+++ b/exercises/accumulate/accumulate.test.ts
@@ -25,7 +25,7 @@ describe('accumulate()', () => {
     })
 
     xit('accumulate recursively', () => {
-        const result = accumulate('a b c'.split(/\s/), (char: string) => accumulate('1 2 3'.split(/\s/), (digit: number) => char + digit))
+        const result = accumulate('a b c'.split(/\s/), (char: string) => accumulate('1 2 3'.split(/\s/), (digit: string) => char + digit))
 
         expect(result).toEqual([['a1', 'a2', 'a3'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3']])
     })


### PR DESCRIPTION
Please, correct me if I'm wrong, but the type of an element of `arr` variable here will be a string:

```js
const arr = '1 2 3'.split(/\s/)
typeof arr[0] // => 'string'
```
so the callback argument of this `accumulate` function call:

```js
accumulate('1 2 3'.split(/\s/), (digit: number) => char + digit)
```

should provide a function with a type signature: 
`(item: string) => T` where `T` is a return value type.

Fun fact, this was caught by TS type system and `accumulate` function signature type defined as:
`function accumulate<T, U>(collection: T[], accumulator: (item: T) => U): U[]`