### PR TITLE
 difference-of-sums: renamed squareOfSums to squareOfSum 

### DIFF
--- a/exercises/difference-of-squares/difference-of-squares.example.ts
+++ b/exercises/difference-of-squares/difference-of-squares.example.ts
@@ -1,15 +1,15 @@
 export default class Squares {
-    squareOfSums: number
+    squareOfSum: number
     sumOfSquares: number
     difference: number
 
     constructor(int: number) {
-        this.squareOfSums = this._squareOfSums(int)
+        this.squareOfSum = this._squareOfSum(int)
         this.sumOfSquares = this._sumOfSquares(int)
         this.difference = this._difference()
     }
 
-    private _squareOfSums(int: number) {
+    private _squareOfSum(int: number) {
         let sum = 0
         let i = 1
 
@@ -34,6 +34,6 @@ export default class Squares {
     }
 
     private _difference() {
-        return this.squareOfSums - this.sumOfSquares
+        return this.squareOfSum - this.sumOfSquares
     }
 }

--- a/exercises/difference-of-squares/difference-of-squares.test.ts
+++ b/exercises/difference-of-squares/difference-of-squares.test.ts
@@ -5,8 +5,8 @@ describe('Squares', () => {
   describe('up to 5', () => {
     const squares = new Squares(5)
 
-    it('gets the square of sums', () => {
-      expect(squares.squareOfSums).toBe(225)
+    it('gets the square of sum', () => {
+      expect(squares.squareOfSum).toBe(225)
     })
 
     xit('gets the sum of squares', () => {
@@ -22,8 +22,8 @@ describe('Squares', () => {
   describe('up to 10', () => {
     const squares = new Squares(10)
 
-    xit('gets the square of sums', () => {
-      expect(squares.squareOfSums).toBe(3025)
+    xit('gets the square of sum', () => {
+      expect(squares.squareOfSum).toBe(3025)
     })
 
     xit('gets the sum of squares', () => {
@@ -39,8 +39,8 @@ describe('Squares', () => {
   describe('up to 100', () => {
     const squares = new Squares(100)
 
-    xit('gets the square of sums', () => {
-      expect(squares.squareOfSums).toBe(25502500)
+    xit('gets the square of sum', () => {
+      expect(squares.squareOfSum).toBe(25502500)
     })
 
     xit('gets the sum of squares', () => {

--- a/exercises/difference-of-squares/package.json
+++ b/exercises/difference-of-squares/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtypescript",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Exercism exercises in Typescript.",
   "author": "",
   "private": true,

--- a/exercises/difference-of-squares/package.json
+++ b/exercises/difference-of-squares/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtypescript",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Exercism exercises in Typescript.",
   "author": "",
   "private": true,


### PR DESCRIPTION
In exercise "difference-of-sums", renamed `squareOfSums` to `squareOfSum`, and some instances of sums to sum. Modified version number as well.