### PR TITLE
simple-cipher: Add test to disallow mixed case key

### DIFF
--- a/exercises/simple-cipher/simple-cipher.example.ts
+++ b/exercises/simple-cipher/simple-cipher.example.ts
@@ -6,11 +6,10 @@ class SimpleCipher {
             for (let i = 0; i < 100; i++) {
                 this.key += String.fromCharCode(Math.random() * 26 + 97)
             }
-        } else {
-            this.key = key!
-        }
-        if (!/[a-z]/.test(key!)) {
+        } else if (!/^[a-z]+$/.test(key)) {
             throw new Error('Bad key')
+        } else {
+            this.key = key
         }
     }
 

--- a/exercises/simple-cipher/simple-cipher.test.ts
+++ b/exercises/simple-cipher/simple-cipher.test.ts
@@ -45,6 +45,12 @@ describe('Incorrect key cipher', () => {
         }).toThrowError('Bad key')
     })
 
+    xit('throws an error with a mixed case key', () => {
+        expect(() => {
+            new SimpleCipher('AbcdEF')
+        }).toThrowError('Bad key')
+    })
+
     xit('throws an error with a numeric key', () => {
         expect(() => {
             new SimpleCipher('12345')


### PR DESCRIPTION
Hi,

During mentoring, I came across a solution that checks if the key is valid (i.e. only contains alpha ascii lower-case letters) by testing

    if (key === key.toUpperCase()) {
        throw new Error('Bad key')
    }

This passes the current "throws an error with an all caps key" test but allows mixed-case keys, which I believe should actually be invalid. So, I'm proposing a new test to test for this situation.