### PR TITLE
`concat` should be applied to a list of lists.

### DIFF
--- a/exercises/list-ops/list-ops.example.ts
+++ b/exercises/list-ops/list-ops.example.ts
@@ -12,8 +12,11 @@ class List<T> {
         return this
     }
 
-    concat(otherList: List<T>) {
-        return this.append(otherList)
+    concat(listOfLists: List<List<T>>) {
+        for (const list of listOfLists.values) {
+            this.append(list)
+        }
+        return this
     }
 
     filter(operation: (arg: T) => boolean) {
@@ -70,7 +73,6 @@ class List<T> {
         }
         return this
     }
-
 }
 
 export default List

--- a/exercises/list-ops/list-ops.test.ts
+++ b/exercises/list-ops/list-ops.test.ts
@@ -23,7 +23,7 @@ describe('append entries to a list and return the new list', () => {
 describe('concat lists and lists of lists into new list', () => {
     xit('empty list', () => {
         const list1 = new List()
-        const list2 = new List()
+        const list2 = new List([])
         expect(list1.concat(list2).values).toEqual([])
     })
 
@@ -32,7 +32,8 @@ describe('concat lists and lists of lists into new list', () => {
         const list2 = new List([3])
         const list3 = new List([])
         const list4 = new List([4, 5, 6])
-        expect(list1.concat(list2).concat(list3).concat(list4).values).toEqual([1, 2, 3, 4, 5, 6])
+        const listOfLists = new List([list2, list3, list4])
+        expect(list1.concat(listOfLists).values).toEqual([1, 2, 3, 4, 5, 6])
     })
 })
 


### PR DESCRIPTION
`List.concat` in the TypeScript track is just a duplicate of `List.append`.

This PR is similar to the [one merged to the JavaScript track](exercism/javascript#550) aligning the TypeScript track with the JavaScript tracks and other tracks, like for example, the [Python track](https://github.com/exercism/python/blob/master/exercises/list-ops/list_ops_test.py#L26), making the `concat` method more useful.