### PR TITLE
Fix Robot-Name test

### DIFF
--- a/exercises/robot-name/robot-name.example.ts
+++ b/exercises/robot-name/robot-name.example.ts
@@ -12,7 +12,7 @@ function  generateRandomLetter(): string {
 
 export default class RobotName {
     private _name: string
-    private usedNames = new Set<string>()
+    private static usedNames = new Set<string>()
 
     get name(): string {
         return this._name
@@ -24,10 +24,10 @@ export default class RobotName {
 private generateName(): string {
     const numberPart = (unified_random() % 899) + 100
     let result = generateRandomLetter() + generateRandomLetter() + numberPart
-    while (this.usedNames.has(result)) {
+    while (RobotName.usedNames.has(result)) {
         result = generateRandomLetter() + generateRandomLetter() + numberPart
     }
-    this.usedNames.add(result)
+    RobotName.usedNames.add(result)
     return result
 }
     resetName() {

--- a/exercises/robot-name/robot-name.test.ts
+++ b/exercises/robot-name/robot-name.test.ts
@@ -31,16 +31,20 @@ describe('Robot', () => {
   })
 
   xit('should set a unique name after reset', () => {
+    const otherRobot = new Robot()
     const NUMBER_OF_ROBOTS = 10000
     const usedNames = new Set()
 
     usedNames.add(robot.name)
-    for (let i = 0; i < NUMBER_OF_ROBOTS; i++) {
+    usedNames.add(otherRobot.name)
+    for (let i = 0; i < NUMBER_OF_ROBOTS / 2; i++) {
       robot.resetName()
+      otherRobot.resetName()
       usedNames.add(robot.name)
+      usedNames.add(otherRobot.name)
     }
 
-    expect(usedNames.size).toEqual(NUMBER_OF_ROBOTS + 1)
+    expect(usedNames.size).toEqual(NUMBER_OF_ROBOTS + 2)
   })
 
   xit('new names should not be sequential', () => {

--- a/exercises/robot-name/robot-name.test.ts
+++ b/exercises/robot-name/robot-name.test.ts
@@ -31,7 +31,7 @@ describe('Robot', () => {
   })
 
   xit('should set a unique name after reset', () => {
-    const otherRobot = new Robot()
+    const otherRobot = new RobotName()
     const NUMBER_OF_ROBOTS = 10000
     const usedNames = new Set()
 


### PR DESCRIPTION
From the **Robot Name** description:

> Manage robot factory settings.
>
> When robots come off the factory floor, they have no name.

This implies that no two robots in the wild will have the same name. The `'should set a unique name after reset'` test only tests the used robot names from one single instance, as opposed to testing against all the robots the came from the factory.

To remedy this, I have 

- added another robot instance to the test
- changed the `usedNames` property in the robot-name.example.ts to be a `static` property

If this is not in the spirit of the activity, please let me know and I will close this.
Thanks for your time.