### PR TITLE
Make `cleans numbers` tests' inputs valid phone numbers

### DIFF
--- a/exercises/phone-number/phone-number.test.ts
+++ b/exercises/phone-number/phone-number.test.ts
@@ -3,18 +3,18 @@ import PhoneNumber from './phone-number'
 describe('PhoneNumber()', () => {
 
   it('cleans the number', () => {
-    const phone = new PhoneNumber('(123) 456-7890')
-    expect(phone.number()).toEqual('1234567890')
+    const phone = new PhoneNumber('(223) 456-7890')
+    expect(phone.number()).toEqual('2234567890')
   })
 
   xit('cleans numbers with dots', () => {
-    const phone = new PhoneNumber('123.456.7890')
-    expect(phone.number()).toEqual('1234567890')
+    const phone = new PhoneNumber('223.456.7890')
+    expect(phone.number()).toEqual('2234567890')
   })
 
   xit('cleans numbers with multiple spaces', () => {
-    const phone = new PhoneNumber('123 456   7890   ')
-    expect(phone.number()).toEqual('1234567890')
+    const phone = new PhoneNumber('223 456   7890   ')
+    expect(phone.number()).toEqual('2234567890')
   })
 
   xit('invalid when 9 digits', () => {


### PR DESCRIPTION
Change the first number of the input phone numbers from a `1` to a `2` because area codes can't start with `1`. Having a `1` as the first digit in a 10 digit number is disallowed as per the instructions for this exercise. If the student implements a check for that, theses tests would fail.

The JS track has already implemented this change and this commit brings the tests in line with the [problem-specification](https://github.com/exercism/problem-specifications/blob/master/exercises/phone-number/canonical-data.json)