### PR TITLE
Suggested reorder of tests for space-age

### DIFF
--- a/exercises/space-age/space-age.test.ts
+++ b/exercises/space-age/space-age.test.ts
@@ -1,56 +1,55 @@
-import SpaceAge from './space-age'
+import SpaceAge from "./space-age";
 
-describe('Space Age', () => {
+describe("Space Age", () => {
+  it("age in seconds", () => {
+    const age = new SpaceAge(1000000);
+    expect(age.seconds).toEqual(1000000);
+  });
 
-  it('age in seconds', () => {
-    const age = new SpaceAge(1000000)
-    expect(age.seconds).toEqual(1000000)
-  })
+  xit("age in earth years", () => {
+    const age = new SpaceAge(1000000000);
+    expect(age.onEarth()).toEqual(31.69);
+  });
 
-  xit('age in earth years', () => {
-    const age = new SpaceAge(1000000000)
-    expect(age.onEarth()).toEqual(31.69)
-  })
+  xit("age in mercury years", () => {
+    const age = new SpaceAge(2134835688);
+    expect(age.onMercury()).toEqual(280.88);
+    expect(age.onEarth()).toEqual(67.65);
+  });
 
-  xit('age in mercury years', () => {
-    const age = new SpaceAge(2134835688)
-    expect(age.onEarth()).toEqual(67.65)
-    expect(age.onMercury()).toEqual(280.88)
-  })
+  xit("age in venus years", () => {
+    const age = new SpaceAge(189839836);
+    expect(age.onVenus()).toEqual(9.78);
+    expect(age.onEarth()).toEqual(6.02);
+  });
 
-  xit('age in venus years', () => {
-    const age = new SpaceAge(189839836)
-    expect(age.onEarth()).toEqual(6.02)
-    expect(age.onVenus()).toEqual(9.78)
-  })
+  xit("age in mars years", () => {
+    const age = new SpaceAge(2329871239);
+    expect(age.onMars()).toEqual(39.25);
+    expect(age.onEarth()).toEqual(73.83);
+  });
 
-  xit('age in mars years', () => {
-    const age = new SpaceAge(2329871239)
-    expect(age.onEarth()).toEqual(73.83)
-    expect(age.onMars()).toEqual(39.25)
-  })
+  xit("age in jupiter years", () => {
+    const age = new SpaceAge(901876382);
+    expect(age.onJupiter()).toEqual(2.41);
+    expect(age.onEarth()).toEqual(28.58);
+  });
 
-  xit('age in jupiter years', () => {
-    const age = new SpaceAge(901876382)
-    expect(age.onEarth()).toEqual(28.58)
-    expect(age.onJupiter()).toEqual(2.41)
-  })
+  xit("age in saturn years", () => {
+    const age = new SpaceAge(3000000000);
+    expect(age.onSaturn()).toEqual(3.23);
+    expect(age.onEarth()).toEqual(95.06);
+  });
 
-  xit('age in saturn years', () => {
-    const age = new SpaceAge(3000000000)
-    expect(age.onEarth()).toEqual(95.06)
-    expect(age.onSaturn()).toEqual(3.23)
-  })
+  xit("age in uranus years", () => {
+    const age = new SpaceAge(3210123456);
+    expect(age.onUranus()).toEqual(1.21);
+    expect(age.onEarth()).toEqual(101.72);
+  });
 
-  xit('age in uranus years', () => {
-    const age = new SpaceAge(3210123456)
-    expect(age.onEarth()).toEqual(101.72)
-    expect(age.onUranus()).toEqual(1.21)
-  })
-
-  xit('age in neptune year', () => {
-    const age = new SpaceAge(8210123456)
-    expect(age.onEarth()).toEqual(260.16)
-    expect(age.onNeptune()).toEqual(1.58)
-  })
-})
+  xit("age in neptune year", () => {
+    const age = new SpaceAge(8210123456);
+    expect(age.onNeptune()).toEqual(1.58);
+    expect(age.onEarth()).toEqual(260.16);
+  });
+});


### PR DESCRIPTION
Observations:  
- The instructions don't say anything about rounding but the tests expect rounded answers
- The algorithm necessary for calculating age on Earth is slightly different than that to calculate age on any other planet
- There is already a test for checking that the value of age on Earth is accurate
- Each 'it' block testing for the correct age on different planets begins with an 'expect' for Earth age
- When there are multiple expects in an 'it' block and the first expect fails, only that expect is shown as failing when running the test

In the event that the programmer has not implemented the necessary rounding, it is possible for them to be led to believe that they simply have a rounding error when it's possible that their algorithm for determining the age on other planets is fundamentally flawed.  

Suggestion:
It might be beneficial to have the order of the expects flipped so that each planet test first tests the target planet and then additionally checks for the accurate Earth age.