### PR TITLE
Change 'sudo: true' to 'sudo: required'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 
 cache: yarn
 
-sudo: true
+sudo: required
 
 before_install:
   - gem install bundler


### PR DESCRIPTION
See [1] and [2] for attempts to standardize this field.

The typescript track is the only track that enables this Travis feature using 'sudo: true' rather than 'sudo: required'.

```
» for f in $(find . -name .travis.yml); do grep -H 'sudo:.*' $f; done | grep -v false
./purescript/.travis.yml:sudo: required
./cfml/.travis.yml:sudo: required
./typescript/.travis.yml:sudo: true
./swift/.travis.yml:      sudo: required
```

This PR does not assess whether 'sudo: true' / 'sudo: required' is preferred over omitting it.

Related issue: exercism/exercism#4793

[1]: https://github.com/travis-ci/docs-travis-ci-com/issues/1792
[2]: https://github.com/travis-ci/docs-travis-ci-com/pull/2121/files