### PR TITLE
fix(phone-number): Align 11-digit phone number test case

### DIFF
--- a/exercises/phone-number/phone-number.test.ts
+++ b/exercises/phone-number/phone-number.test.ts
@@ -28,8 +28,8 @@ describe('PhoneNumber()', () => {
   })
 
   xit('valid when 11 digits and starting with 1', () => {
-    const phone = new PhoneNumber('11234567890')
-    expect(phone.number()).toEqual('1234567890')
+    const phone = new PhoneNumber('12234567890')
+    expect(phone.number()).toEqual('2234567890')
   })
 
   xit('invalid when 12 digits', () => {


### PR DESCRIPTION
In the [readme](https://github.com/exercism/typescript/blob/master/exercises/phone-number/README.md) it says:

> The format is usually represented as
>
> ```
> (NXX)-NXX-XXXX
> ```
>
>where N is any digit from 2 through 9 and X is any digit from 0 through 9.

The original test phone number `11234567890` doesn't fit into this format.

This fixes the test case by aligning it with the [JavaScript version](https://github.com/exercism/javascript/blob/master/exercises/phone-number/phone-number.spec.js#L30).