### PR TITLE
Use `it` instead of `test` in resistor-color-duo

### DIFF
--- a/exercises/resistor-color-duo/resistor-color-duo.test.ts
+++ b/exercises/resistor-color-duo/resistor-color-duo.test.ts
@@ -1,31 +1,32 @@
 import { ResistorColor } from "./resistor-color-duo"
 
 describe("Resistor Colors", () => {
-  xtest("Brown and black", () => {
+  it("Brown and black", () => {
     const resistorColor = new ResistorColor(["brown", "black"])
     expect(resistorColor.value()).toEqual(10)
   })
 
-  xtest("Blue and grey", () => {
+  xit("Blue and grey", () => {
     const resistorColor = new ResistorColor(["blue", "grey"])
     expect(resistorColor.value()).toEqual(68)
   })
 
-  xtest("Yellow and violet", () => {
+  xit("Yellow and violet", () => {
     const resistorColor = new ResistorColor(["yellow", "violet"])
     expect(resistorColor.value()).toEqual(47)
   })
 
-  xtest("Orange and orange", () => {
+  xit("Orange and orange", () => {
     const resistorColor = new ResistorColor(["orange", "orange"])
     expect(resistorColor.value()).toEqual(33)
   })
 
-  xtest("Ignore additional colors", () => {
+  xit("Ignore additional colors", () => {
     const resistorColor = new ResistorColor(["green", "brown", "orange"])
     expect(resistorColor.value()).toEqual(51)
   })
-  xtest("Throws error when not enough colors", () => {
+
+  xit("Throws error when not enough colors", () => {
     expect(() => new ResistorColor(["green"])).toThrowError(
       "At least two colors need to be present"
     )


### PR DESCRIPTION
It will also now not skip the first test. This is to make the exercise
more consistent with the other exercises.