### PR TITLE
Fix unclear hello-world installation instructions

### DIFF
--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -19,7 +19,7 @@ If everything goes well, you will be ready to fetch your first real exercise.
 Go through the setup instructions for TypeScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/typescript
+[https://exercism.io/tracks/typescript/installation](https://exercism.io/tracks/typescript/installation)
 
 ## Requirements
 


### PR DESCRIPTION
`hello-world`'s installation instructions are extremely unclear, and the link directs users to the language homepage. Also checked all other exercises to make sure the links are all correctly placed.

![image](https://user-images.githubusercontent.com/13333578/83375367-abc10200-a39c-11ea-8a11-e607ef37d82c.png)
