### PR TITLE
[word-count] Added tests to ensure multiple newlines and tabs are handled

### DIFF
--- a/exercises/word-count/word-count.example.ts
+++ b/exercises/word-count/word-count.example.ts
@@ -2,9 +2,7 @@ class Words {
   public count(input: string): Map<string, number> {
     const inputArray = input
       .toLowerCase()
-      .replace(/\n/m, " ")
-      .replace(/\t/m, " ")
-      .split(" ")
+      .split(/\s+/)
     const inputMap = new Map<string, number>()
 
     for (const each of inputArray) {

--- a/exercises/word-count/word-count.test.ts
+++ b/exercises/word-count/word-count.test.ts
@@ -43,9 +43,19 @@ describe('words()', () => {
     expect(words.count('hello\nworld')).toEqual(expectedCounts)
   })
 
+  xit('counts multiple multiline characters', () => {
+    const expectedCounts = new Map(Object.entries({ hello: 1, multiple: 1, newlines: 1 }))
+    expect(words.count('hello\nmultiple\nnewlines')).toEqual(expectedCounts)
+  })
+
   xit('counts tabs', () => {
     const expectedCounts = new Map(Object.entries({ hello: 1, world: 1 }))
     expect(words.count('hello\tworld')).toEqual(expectedCounts)
+  })
+
+  xit('counts multiple tab characters', () => {
+    const expectedCounts = new Map(Object.entries({ hello: 1, multiple: 1, tabs: 1 }))
+    expect(words.count('hello\tmultiple\ttabs')).toEqual(expectedCounts)
   })
 
   xit('counts multiple spaces as one', () => {


### PR DESCRIPTION
This solution passes existing tests, but maybe it should not:
```TypeScript
public count(source: string): Map<string, number> {
  return source
    .trim()
    .replace("\n", " ")
    .replace("\t", " ")
    .split(" ")
    .filter((x) => x)
    .map((x) => x.toLocaleLowerCase())
    .reduce(
      (acc: Map<string, number>, curr: string): Map<string, number> =>
        acc.set(curr, acc.get(curr) ? acc.get(curr) + 1 : 1),
      new Map<string, number>()
    );
}
```
If there are multiple newline characters or tabs in-between words in the given string, it will fail. This situation is not tested for, though.

I was also considering adding a test for `\r` and `\r\n` newlines, but maybe that's not valuable enough for this exercise.

If I am missing anything in this PR, please let me know. I've read the contributing guidelines, but I'm not sure if I need to adjust the package version or make updates to the canonical exercise definitions. I did see a definition in there (["handles expanded lists"](https://github.com/exercism/problem-specifications/blob/master/exercises/word-count/canonical-data.json#L58)) which has an input containing multiple newline characters.