### PR TITLE
pythagorean-triplet: Clarify test expectations

### DIFF
--- a/exercises/pythagorean-triplet/pythagorean-triplet.example.ts
+++ b/exercises/pythagorean-triplet/pythagorean-triplet.example.ts
@@ -1,3 +1,9 @@
+interface WhereOptions {
+  maxFactor: number;
+  minFactor?: number;
+  sum?: number;
+}
+
 export default class Triplet {
   private readonly a: number
   private readonly b: number
@@ -21,9 +27,9 @@ export default class Triplet {
     return this.a * this.b * this.c
   }
 
-  public static where(maxFactor: number, minFactor?: number, sum?: number): Triplet[] {
+  public static where(options: WhereOptions): Triplet[] {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    return new Triplets(maxFactor, minFactor, sum).toArray()
+    return new Triplets(options.maxFactor, options.minFactor, options.sum).toArray()
   }
 }
 

--- a/exercises/pythagorean-triplet/pythagorean-triplet.test.ts
+++ b/exercises/pythagorean-triplet/pythagorean-triplet.test.ts
@@ -18,7 +18,7 @@ describe("Triplet", () => {
   })
 
   xit("can make triplets up to 10", () => {
-    const triplets = Triplet.where(10)
+    const triplets = Triplet.where({ maxFactor: 10 })
     const products = triplets
       .sort()
       .map((triplet: Triplet) => triplet.product())
@@ -26,7 +26,7 @@ describe("Triplet", () => {
   })
 
   xit("can make triplets 11 through 20", () => {
-    const triplets = Triplet.where(20, 11)
+    const triplets = Triplet.where({ minFactor: 11, maxFactor: 20 })
     const products = triplets
       .sort()
       .map((triplet: Triplet) => triplet.product())
@@ -34,7 +34,7 @@ describe("Triplet", () => {
   })
 
   xit("can filter on sum", () => {
-    const triplets = Triplet.where(100, undefined, 180)
+    const triplets = Triplet.where({ sum: 180, maxFactor: 100 })
     const products = triplets
       .sort()
       .map((triplet: Triplet) => triplet.product())


### PR DESCRIPTION
The arguments to the `.where()` tests for pythagorean-triplet were too
ambiguous. Mimic the JavaScript test by explicitly naming the arguments.