### PR TITLE
list is always an array

### DIFF
--- a/exercises/accumulate/accumulate.example.ts
+++ b/exercises/accumulate/accumulate.example.ts
@@ -1,7 +1,7 @@
 export default <T, O>(list: T[], accumulator: (arg: T) => O): O[] => {
   const out = []
   let idx = -1
-  const end = Array.isArray(list) ? list.length : 0
+  const end = list.length;
 
   while (++idx < end) {
     out.push(accumulator(list[idx]))

--- a/exercises/accumulate/accumulate.example.ts
+++ b/exercises/accumulate/accumulate.example.ts
@@ -1,7 +1,7 @@
 export default <T, O>(list: T[], accumulator: (arg: T) => O): O[] => {
   const out = []
   let idx = -1
-  const end = list.length;
+  const end = list.length
 
   while (++idx < end) {
     out.push(accumulator(list[idx]))


### PR DESCRIPTION
TypeScript guarantees that list is an array of type T. So `Array.isArray(list)` is unnecessary.