### PR TITLE
Binary Search Tree: Corrected return types on `left` and `right` methods and adjusted tests

### DIFF
--- a/exercises/binary-search-tree/binary-search-tree.example.ts
+++ b/exercises/binary-search-tree/binary-search-tree.example.ts
@@ -1,55 +1,44 @@
-export default class BinarySearchTree {
-  private _data: number
+type BinarySearchTreeMaybe = BinarySearchTree | undefined
+type EachFn = (data: number) => void
+
+class BinarySearchTree {
+  private readonly _data: number
   private _left?: BinarySearchTree
   private _right?: BinarySearchTree
 
-  constructor(_data: number) {
-    this._data = _data
+  constructor(data: number) {
+    this._data = data
   }
 
   public insert(value: number): this {
-    return value <= this._data
-      ? this.insertLeft(value)
-      : this.insertRight(value)
+    if (value <= this._data) {
+      if (this._left) this._left.insert(value)
+      else this._left = new BinarySearchTree(value)
+    } else {
+      if (this._right) this._right.insert(value)
+      else this._right = new BinarySearchTree(value)
+    }
+
+    return this
   }
 
-  public each(fn: (data: number) => void): void {
-    if (this._left) {
-      this._left.each(fn)
-    }
+  public each(fn: EachFn): void {
+    if (this._left) this._left.each(fn)
     fn(this._data)
-    if (this._right) {
-      this._right.each(fn)
-    }
+    if (this._right) this._right.each(fn)
   }
 
   public get data(): number {
     return this._data
   }
 
-  public get left(): BinarySearchTree {
-    return this._left!
+  public get left(): BinarySearchTreeMaybe {
+    return this._left
   }
 
-  public get right(): BinarySearchTree {
-    return this._right!
-  }
-
-  private insertLeft(value: number): this {
-    if (!this._left) {
-      this._left = new BinarySearchTree(value)
-    } else {
-      this._left.insert(value)
-    }
-    return this
-  }
-
-  private insertRight(value: number): this {
-    if (!this._right) {
-      this._right = new BinarySearchTree(value)
-    } else {
-      this._right.insert(value)
-    }
-    return this
+  public get right(): BinarySearchTreeMaybe {
+    return this._right
   }
 }
+
+export default BinarySearchTree

--- a/exercises/binary-search-tree/binary-search-tree.test.ts
+++ b/exercises/binary-search-tree/binary-search-tree.test.ts
@@ -16,7 +16,7 @@ describe('BinarySearchTree', () => {
     four.insert(2)
 
     expect(four.data).toEqual(4)
-    expect(four.left.data).toEqual(2)
+    expect(four.left!.data).toEqual(2)
   })
 
   xit('should insert the same number to the left', () => {
@@ -24,7 +24,7 @@ describe('BinarySearchTree', () => {
     four.insert(4)
 
     expect(four.data).toEqual(4)
-    expect(four.left.data).toEqual(4)
+    expect(four.left!.data).toEqual(4)
   })
 
   xit('should insert a greater number to the right', () => {
@@ -32,7 +32,7 @@ describe('BinarySearchTree', () => {
     four.insert(5)
 
     expect(four.data).toEqual(4)
-    expect(four.right.data).toEqual(5)
+    expect(four.right!.data).toEqual(5)
   })
 
   xit('should deal with a complex tree', () => {
@@ -45,12 +45,12 @@ describe('BinarySearchTree', () => {
     four.insert(5)
 
     expect(four.data).toEqual(4)
-    expect(four.left.data).toEqual(2)
-    expect(four.left.left.data).toEqual(1)
-    expect(four.left.right.data).toEqual(3)
-    expect(four.right.data).toEqual(6)
-    expect(four.right.left.data).toEqual(5)
-    expect(four.right.right.data).toEqual(7)
+    expect(four.left!.data).toEqual(2)
+    expect(four.left!.left!.data).toEqual(1)
+    expect(four.left!.right!.data).toEqual(3)
+    expect(four.right!.data).toEqual(6)
+    expect(four.right!.left!.data).toEqual(5)
+    expect(four.right!.right!.data).toEqual(7)
   })
 
   xit('should iterate over one element', () => {


### PR DESCRIPTION
Issue: https://github.com/exercism/typescript/issues/388
* Updated `left` and `right` method return types and cleaned up example (attempt to modernize to [ECMAScript private fields](https://www.typescriptlang.org/docs/handbook/classes.html#ecmascript-private-fields) thwarted by ESLint https://github.com/typescript-eslint/typescript-eslint/issues/1436).
* Added required non-null assertion operators in test code to get tests to work again.