### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -1,3 +1,5 @@
+# exercise readme insert
+
 ## Setup
 
 Go through the setup instructions for TypeScript to install the necessary

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 [TypeScript](http://www.typescriptlang.org/) (TS) is a superset of JavaScript (JS), created at Microsoft
 in response to frustration developing large-scale applictions in JS. In a large JS project, knowing
 what properties your own objects have, what arguments your functions take (and what type they need to be)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 Install [Yarn](https://yarnpkg.com/lang/en/docs/install):
 
 - **OS X users**: can use `brew install yarn`

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 If you want to learn Typescript, check out the following resources.
 
 - [TS Tutorial](https://www.typescriptlang.org/docs/tutorial.html)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 ## Recommended References
 
 - [TypeScript QuickStart](https://www.typescriptlang.org/docs/tutorial.html)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 Execute the tests with:
 
 ```bash

--- a/exercises/practice/bob/.meta/description.md
+++ b/exercises/practice/bob/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Bob is a lackadaisical teenager. In conversation, his responses are very limited.
 
 Bob answers 'Sure.' if you ask him a question.

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Setup
 
 Go through the setup instructions for TypeScript to

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,1 +1,3 @@
+# Instructions append
+
 Using core language features to build and deconstruct arrays via destructuring, and using the array literal `[]` are allowed, but no functions from the `Array.prototype` should be used.


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
