### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "c79ecacf-6b92-4033-9f25-1f86e7299760",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing TypeScript locally",
+      "blurb": "Learn how to install TypeScript locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "d5553e1b-8432-4b27-a855-d060e830636d",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn TypeScript",
+      "blurb": "An overview of how to get started from scratch with TypeScript"
+    },
+    {
+      "uuid": "bef8b724-0569-4ad9-8e00-5daff3c17057",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the TypeScript track",
+      "blurb": "Learn how to test your TypeScript exercises on Exercism"
+    },
+    {
+      "uuid": "4d00c4da-0f99-4d0c-9a43-aca47128e4fb",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful TypeScript resources",
+      "blurb": "A collection of useful resources to help you master TypeScript"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
