### PR TITLE
Mark inactive maintainer as alumnus

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -23,7 +23,7 @@
     },
     {
       "github_username": "CRivasGomez",
-      "alumnus": false,
+      "alumnus": true,
       "show_on_website": true,
       "name": "Cristian Rivas Gómez",
       "link_text": null,
@@ -43,7 +43,7 @@
     },
     {
       "github_username": "msomji",
-      "alumnus": false,
+      "alumnus": true,
       "show_on_website": false,
       "name": "Maisam Somji",
       "link_text": null,


### PR DESCRIPTION
Dear maintainer,

As we near launching V3 for Beta I'm updating the `maintainers` list. If you're tagged in this message, I've flipped your `alumnus` value to `true`, as you've been inactive for the past months. If I don't hear anything in the next seven days it will remain so.

- If you'd like to not show up on the website, please let me know
- If you'd like to stay on as a maintainer, please let me know

Naturally, if you choose to come back in the future, we always have a place for you, but I need to know who I can count on as we hurdle towards the big update and all the support required thereafter. 

Thank you for all your contributions thusfar.

@msomji