### PR TITLE
Updated online editor code style #394

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
   "version": 3,
   "online_editor": {
     "indent_style": "space",
-    "indent_size": 4
+    "indent_size": 2
   },
   "test_pattern": ".*[.]test[.]ts$",
   "files": {


### PR DESCRIPTION
Fixes #394 

Changed it to 2-Spaces. Seemingly is the code style guideline used by google for JS and TS so I thought it could be a good basis 