### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -45,7 +45,7 @@
       {
         "slug": "resistor-color-duo",
         "name": "Resistor Color Duo",
-        "uuid": "78645d36-12be-11ea-8d71-362b9e155667",
+        "uuid": "fd677d24-72eb-46d9-bfa4-8013e96fa71f",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -197,7 +197,7 @@
       {
         "slug": "linked-list",
         "name": "Linked List",
-        "uuid": "7d42dd76-a6cf-11e7-abc4-cec278b6b50a",
+        "uuid": "5b7ab927-6e4d-480f-b005-d23091e579d6",
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
@@ -529,7 +529,7 @@
       {
         "slug": "two-bucket",
         "name": "Two Bucket",
-        "uuid": "7dd29a19-08f6-8480-2e01-1f7262d8860a",
+        "uuid": "6d187289-27b2-4630-b37b-58553271188a",
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
@@ -820,7 +820,7 @@
       {
         "slug": "prime-factors",
         "name": "Prime Factors",
-        "uuid": "4ecf9470-a959-11e7-abc4-cec278b6b50a",
+        "uuid": "ef38ee9b-39b7-4bb8-9a34-2e19eba92260",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
@@ -897,7 +897,7 @@
       {
         "slug": "circular-buffer",
         "name": "Circular Buffer",
-        "uuid": "3cc210e8-b3bb-11e7-abc4-cec278b6b50a",
+        "uuid": "759aa79d-975a-4b54-b306-618caba8f201",
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
@@ -913,7 +913,7 @@
       {
         "slug": "word-search",
         "name": "Word Search",
-        "uuid": "8ba2c83e-f544-11e9-802a-5aa538984bd8",
+        "uuid": "ab16bfad-960d-405b-aba4-afd142330663",
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
@@ -1048,7 +1048,7 @@
       {
         "slug": "strain",
         "name": "Strain",
-        "uuid": "e16c3064-b2ef-11e7-abc4-cec278b6b50a",
+        "uuid": "160c31bd-814c-4de7-8af5-7cd223763da8",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
