### PR TITLE
🤖 Add average test runner run time to `config.json`

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,18 +21,10 @@
   },
   "test_pattern": ".*[.]test[.]ts$",
   "files": {
-    "solution": [
-      "%{kebab_slug}.ts"
-    ],
-    "test": [
-      "%{kebab_slug}.test.ts"
-    ],
-    "example": [
-      ".meta/proof.ci.ts"
-    ],
-    "exemplar": [
-      ".meta/exemplar.ts"
-    ]
+    "solution": ["%{kebab_slug}.ts"],
+    "test": ["%{kebab_slug}.test.ts"],
+    "example": [".meta/proof.ci.ts"],
+    "exemplar": [".meta/exemplar.ts"]
   },
   "exercises": {
     "concept": [],
@@ -44,11 +36,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "optional_values",
-          "strings",
-          "text_formatting"
-        ]
+        "topics": ["optional_values", "strings", "text_formatting"]
       },
       {
         "slug": "two-fer",
@@ -57,11 +45,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "optional_values",
-          "strings",
-          "text_formatting"
-        ]
+        "topics": ["optional_values", "strings", "text_formatting"]
       },
       {
         "slug": "resistor-color-duo",
@@ -70,10 +54,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "strings",
-          "arrays"
-        ]
+        "topics": ["strings", "arrays"]
       },
       {
         "slug": "leap",
@@ -82,11 +63,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "booleans",
-          "integers",
-          "logic"
-        ]
+        "topics": ["booleans", "integers", "logic"]
       },
       {
         "slug": "resistor-color",
@@ -95,10 +72,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "arrays",
-          "strings"
-        ]
+        "topics": ["arrays", "strings"]
       },
       {
         "slug": "rna-transcription",
@@ -107,10 +81,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "strings",
-          "transforming"
-        ]
+        "topics": ["strings", "transforming"]
       },
       {
         "slug": "space-age",
@@ -119,10 +90,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "classes",
-          "floating_point_numbers"
-        ]
+        "topics": ["classes", "floating_point_numbers"]
       },
       {
         "slug": "pangram",
@@ -195,11 +163,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "arrays",
-          "maps",
-          "sorting"
-        ]
+        "topics": ["arrays", "maps", "sorting"]
       },
       {
         "slug": "clock",
@@ -208,11 +172,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "integers",
-          "logic",
-          "strings"
-        ]
+        "topics": ["integers", "logic", "strings"]
       },
       {
         "slug": "secret-handshake",
@@ -237,12 +197,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "conditionals",
-          "loops"
-        ]
+        "topics": ["algorithms", "arrays", "conditionals", "loops"]
       },
       {
         "slug": "linked-list",
@@ -268,11 +223,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "floating_point_numbers",
-          "math"
-        ]
+        "topics": ["algorithms", "floating_point_numbers", "math"]
       },
       {
         "slug": "atbash-cipher",
@@ -330,11 +281,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "data_structures",
-          "lists",
-          "recursion"
-        ]
+        "topics": ["data_structures", "lists", "recursion"]
       },
       {
         "slug": "word-count",
@@ -358,12 +305,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "algorithms",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["algorithms", "loops", "integers", "math"]
       },
       {
         "slug": "gigasecond",
@@ -372,9 +314,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "time"
-        ]
+        "topics": ["time"]
       },
       {
         "slug": "reverse-string",
@@ -383,10 +323,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "loops",
-          "strings"
-        ]
+        "topics": ["loops", "strings"]
       },
       {
         "slug": "triangle",
@@ -395,12 +332,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "conditionals",
-          "loops",
-          "exception_handling",
-          "integers"
-        ]
+        "topics": ["conditionals", "loops", "exception_handling", "integers"]
       },
       {
         "slug": "collatz-conjecture",
@@ -424,12 +356,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "loops",
-          "integers",
-          "maps",
-          "transforming"
-        ]
+        "topics": ["loops", "integers", "maps", "transforming"]
       },
       {
         "slug": "protein-translation",
@@ -438,12 +365,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "loops",
-          "strings"
-        ]
+        "topics": ["arrays", "conditionals", "loops", "strings"]
       },
       {
         "slug": "raindrops",
@@ -452,12 +374,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "conditionals",
-          "integers",
-          "strings",
-          "transforming"
-        ]
+        "topics": ["conditionals", "integers", "strings", "transforming"]
       },
       {
         "slug": "hamming",
@@ -466,12 +383,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "conditionals",
-          "loops",
-          "equality",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "equality", "strings"]
       },
       {
         "slug": "nucleotide-count",
@@ -495,12 +407,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "maps",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "maps", "strings"]
       },
       {
         "slug": "allergies",
@@ -509,12 +416,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": [
-          "arrays",
-          "bitwise_operations",
-          "conditionals",
-          "loops"
-        ]
+        "topics": ["arrays", "bitwise_operations", "conditionals", "loops"]
       },
       {
         "slug": "perfect-numbers",
@@ -523,13 +425,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["arrays", "conditionals", "loops", "integers", "math"]
       },
       {
         "slug": "complex-numbers",
@@ -538,12 +434,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "loops",
-          "math"
-        ]
+        "topics": ["arrays", "conditionals", "loops", "math"]
       },
       {
         "slug": "luhn",
@@ -552,12 +443,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "conditionals",
-          "loops",
-          "integers",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "integers", "strings"]
       },
       {
         "slug": "grains",
@@ -566,11 +452,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "integers"
-        ]
+        "topics": ["conditionals", "loops", "integers"]
       },
       {
         "slug": "pythagorean-triplet",
@@ -579,13 +461,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
       },
       {
         "slug": "sum-of-multiples",
@@ -594,13 +470,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "integers",
-          "lists",
-          "math"
-        ]
+        "topics": ["conditionals", "loops", "integers", "lists", "math"]
       },
       {
         "slug": "acronym",
@@ -609,12 +479,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "loops",
-          "regular_expressions",
-          "strings",
-          "transforming"
-        ]
+        "topics": ["loops", "regular_expressions", "strings", "transforming"]
       },
       {
         "slug": "anagram",
@@ -623,10 +488,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "filtering",
-          "strings"
-        ]
+        "topics": ["filtering", "strings"]
       },
       {
         "slug": "isogram",
@@ -635,13 +497,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "conditionals",
-          "loops",
-          "filtering",
-          "searching",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "filtering", "searching", "strings"]
       },
       {
         "slug": "roman-numerals",
@@ -664,12 +520,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "loops",
-          "exception_handling",
-          "strings",
-          "text_formatting"
-        ]
+        "topics": ["loops", "exception_handling", "strings", "text_formatting"]
       },
       {
         "slug": "phone-number",
@@ -678,10 +529,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "parsing",
-          "transforming"
-        ]
+        "topics": ["parsing", "transforming"]
       },
       {
         "slug": "two-bucket",
@@ -743,10 +591,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "text_formatting"
-        ]
+        "topics": ["algorithms", "text_formatting"]
       },
       {
         "slug": "house",
@@ -755,13 +600,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "loops",
-          "recursion",
-          "strings"
-        ]
+        "topics": ["arrays", "conditionals", "loops", "recursion", "strings"]
       },
       {
         "slug": "isbn-verifier",
@@ -832,11 +671,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "strings"]
       },
       {
         "slug": "say",
@@ -861,13 +696,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "loops",
-          "matrices",
-          "strings"
-        ]
+        "topics": ["arrays", "conditionals", "loops", "matrices", "strings"]
       },
       {
         "slug": "saddle-points",
@@ -958,10 +787,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": [
-          "algorithms",
-          "games"
-        ]
+        "topics": ["algorithms", "games"]
       },
       {
         "slug": "connect",
@@ -1003,13 +829,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
       },
       {
         "slug": "diamond",
@@ -1035,11 +855,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "math"
-        ]
+        "topics": ["conditionals", "loops", "math"]
       },
       {
         "slug": "binary-search-tree",
@@ -1048,12 +864,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "recursion"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "recursion"]
       },
       {
         "slug": "sublist",
@@ -1128,13 +939,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "integers",
-          "math",
-          "recursion"
-        ]
+        "topics": ["conditionals", "loops", "integers", "math", "recursion"]
       },
       {
         "slug": "palindrome-products",
@@ -1143,13 +948,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
       },
       {
         "slug": "diffie-hellman",
@@ -1223,11 +1022,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "algorithms",
-          "integers",
-          "math"
-        ]
+        "topics": ["algorithms", "integers", "math"]
       },
       {
         "slug": "run-length-encoding",
@@ -1253,10 +1048,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "strings",
-          "iterators"
-        ]
+        "topics": ["strings", "iterators"]
       },
       {
         "slug": "strain",
@@ -1282,12 +1074,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "callbacks",
-          "conditionals",
-          "lists"
-        ]
+        "topics": ["algorithms", "callbacks", "conditionals", "lists"]
       },
       {
         "slug": "all-your-base",
@@ -1312,12 +1099,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "arrays",
-          "lists",
-          "loops",
-          "recursion"
-        ]
+        "topics": ["arrays", "lists", "loops", "recursion"]
       },
       {
         "slug": "matching-brackets",
@@ -1326,11 +1108,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "parsing",
-          "stacks",
-          "strings"
-        ]
+        "topics": ["parsing", "stacks", "strings"]
       },
       {
         "slug": "minesweeper",
@@ -1339,11 +1117,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "games"
-        ]
+        "topics": ["algorithms", "arrays", "games"]
       },
       {
         "slug": "queen-attack",
@@ -1369,11 +1143,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "algorithms",
-          "closures",
-          "reactive_programming"
-        ]
+        "topics": ["algorithms", "closures", "reactive_programming"]
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -16,12 +16,23 @@
     "ace_editor_language": "typescript",
     "highlightjs_language": "typescript"
   },
+  "test_runner": {
+    "average_run_time": 4.0
+  },
   "test_pattern": ".*[.]test[.]ts$",
   "files": {
-    "solution": ["%{kebab_slug}.ts"],
-    "test": ["%{kebab_slug}.test.ts"],
-    "example": [".meta/proof.ci.ts"],
-    "exemplar": [".meta/exemplar.ts"]
+    "solution": [
+      "%{kebab_slug}.ts"
+    ],
+    "test": [
+      "%{kebab_slug}.test.ts"
+    ],
+    "example": [
+      ".meta/proof.ci.ts"
+    ],
+    "exemplar": [
+      ".meta/exemplar.ts"
+    ]
   },
   "exercises": {
     "concept": [],
@@ -33,7 +44,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["optional_values", "strings", "text_formatting"]
+        "topics": [
+          "optional_values",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "two-fer",
@@ -42,7 +57,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["optional_values", "strings", "text_formatting"]
+        "topics": [
+          "optional_values",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "resistor-color-duo",
@@ -51,7 +70,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["strings", "arrays"]
+        "topics": [
+          "strings",
+          "arrays"
+        ]
       },
       {
         "slug": "leap",
@@ -60,7 +82,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["booleans", "integers", "logic"]
+        "topics": [
+          "booleans",
+          "integers",
+          "logic"
+        ]
       },
       {
         "slug": "resistor-color",
@@ -69,7 +95,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["arrays", "strings"]
+        "topics": [
+          "arrays",
+          "strings"
+        ]
       },
       {
         "slug": "rna-transcription",
@@ -78,7 +107,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["strings", "transforming"]
+        "topics": [
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "space-age",
@@ -87,7 +119,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["classes", "floating_point_numbers"]
+        "topics": [
+          "classes",
+          "floating_point_numbers"
+        ]
       },
       {
         "slug": "pangram",
@@ -160,7 +195,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "maps", "sorting"]
+        "topics": [
+          "arrays",
+          "maps",
+          "sorting"
+        ]
       },
       {
         "slug": "clock",
@@ -169,7 +208,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["integers", "logic", "strings"]
+        "topics": [
+          "integers",
+          "logic",
+          "strings"
+        ]
       },
       {
         "slug": "secret-handshake",
@@ -194,7 +237,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "arrays", "conditionals", "loops"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "conditionals",
+          "loops"
+        ]
       },
       {
         "slug": "linked-list",
@@ -220,7 +268,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "floating_point_numbers", "math"]
+        "topics": [
+          "algorithms",
+          "floating_point_numbers",
+          "math"
+        ]
       },
       {
         "slug": "atbash-cipher",
@@ -278,7 +330,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["data_structures", "lists", "recursion"]
+        "topics": [
+          "data_structures",
+          "lists",
+          "recursion"
+        ]
       },
       {
         "slug": "word-count",
@@ -302,7 +358,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["algorithms", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "gigasecond",
@@ -311,7 +372,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["time"]
+        "topics": [
+          "time"
+        ]
       },
       {
         "slug": "reverse-string",
@@ -320,7 +383,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["loops", "strings"]
+        "topics": [
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "triangle",
@@ -329,7 +395,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["conditionals", "loops", "exception_handling", "integers"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "exception_handling",
+          "integers"
+        ]
       },
       {
         "slug": "collatz-conjecture",
@@ -353,7 +424,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["loops", "integers", "maps", "transforming"]
+        "topics": [
+          "loops",
+          "integers",
+          "maps",
+          "transforming"
+        ]
       },
       {
         "slug": "protein-translation",
@@ -362,7 +438,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["arrays", "conditionals", "loops", "strings"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "raindrops",
@@ -371,7 +452,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["conditionals", "integers", "strings", "transforming"]
+        "topics": [
+          "conditionals",
+          "integers",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "hamming",
@@ -380,7 +466,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["conditionals", "loops", "equality", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "equality",
+          "strings"
+        ]
       },
       {
         "slug": "nucleotide-count",
@@ -404,7 +495,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "maps", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "maps",
+          "strings"
+        ]
       },
       {
         "slug": "allergies",
@@ -413,7 +509,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["arrays", "bitwise_operations", "conditionals", "loops"]
+        "topics": [
+          "arrays",
+          "bitwise_operations",
+          "conditionals",
+          "loops"
+        ]
       },
       {
         "slug": "perfect-numbers",
@@ -422,7 +523,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["arrays", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "complex-numbers",
@@ -431,7 +538,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "conditionals", "loops", "math"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "math"
+        ]
       },
       {
         "slug": "luhn",
@@ -440,7 +552,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["conditionals", "loops", "integers", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers",
+          "strings"
+        ]
       },
       {
         "slug": "grains",
@@ -449,7 +566,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "integers"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers"
+        ]
       },
       {
         "slug": "pythagorean-triplet",
@@ -458,7 +579,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "sum-of-multiples",
@@ -467,7 +594,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "integers", "lists", "math"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers",
+          "lists",
+          "math"
+        ]
       },
       {
         "slug": "acronym",
@@ -476,7 +609,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["loops", "regular_expressions", "strings", "transforming"]
+        "topics": [
+          "loops",
+          "regular_expressions",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "anagram",
@@ -485,7 +623,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["filtering", "strings"]
+        "topics": [
+          "filtering",
+          "strings"
+        ]
       },
       {
         "slug": "isogram",
@@ -494,7 +635,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["conditionals", "loops", "filtering", "searching", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "filtering",
+          "searching",
+          "strings"
+        ]
       },
       {
         "slug": "roman-numerals",
@@ -517,7 +664,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["loops", "exception_handling", "strings", "text_formatting"]
+        "topics": [
+          "loops",
+          "exception_handling",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "phone-number",
@@ -526,7 +678,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["parsing", "transforming"]
+        "topics": [
+          "parsing",
+          "transforming"
+        ]
       },
       {
         "slug": "two-bucket",
@@ -588,7 +743,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "text_formatting"]
+        "topics": [
+          "algorithms",
+          "text_formatting"
+        ]
       },
       {
         "slug": "house",
@@ -597,7 +755,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "conditionals", "loops", "recursion", "strings"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "recursion",
+          "strings"
+        ]
       },
       {
         "slug": "isbn-verifier",
@@ -668,7 +832,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "say",
@@ -693,7 +861,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "conditionals", "loops", "matrices", "strings"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "matrices",
+          "strings"
+        ]
       },
       {
         "slug": "saddle-points",
@@ -784,7 +958,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["algorithms", "games"]
+        "topics": [
+          "algorithms",
+          "games"
+        ]
       },
       {
         "slug": "connect",
@@ -826,7 +1003,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "diamond",
@@ -852,7 +1035,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "math"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "math"
+        ]
       },
       {
         "slug": "binary-search-tree",
@@ -861,7 +1048,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["algorithms", "conditionals", "loops", "recursion"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "recursion"
+        ]
       },
       {
         "slug": "sublist",
@@ -936,7 +1128,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "integers", "math", "recursion"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers",
+          "math",
+          "recursion"
+        ]
       },
       {
         "slug": "palindrome-products",
@@ -945,7 +1143,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "diffie-hellman",
@@ -1019,7 +1223,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["algorithms", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "run-length-encoding",
@@ -1045,7 +1253,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["strings", "iterators"]
+        "topics": [
+          "strings",
+          "iterators"
+        ]
       },
       {
         "slug": "strain",
@@ -1071,7 +1282,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "callbacks", "conditionals", "lists"]
+        "topics": [
+          "algorithms",
+          "callbacks",
+          "conditionals",
+          "lists"
+        ]
       },
       {
         "slug": "all-your-base",
@@ -1096,7 +1312,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["arrays", "lists", "loops", "recursion"]
+        "topics": [
+          "arrays",
+          "lists",
+          "loops",
+          "recursion"
+        ]
       },
       {
         "slug": "matching-brackets",
@@ -1105,7 +1326,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["parsing", "stacks", "strings"]
+        "topics": [
+          "parsing",
+          "stacks",
+          "strings"
+        ]
       },
       {
         "slug": "minesweeper",
@@ -1114,7 +1339,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["algorithms", "arrays", "games"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "games"
+        ]
       },
       {
         "slug": "queen-attack",
@@ -1140,7 +1369,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["algorithms", "closures", "reactive_programming"]
+        "topics": [
+          "algorithms",
+          "closures",
+          "reactive_programming"
+        ]
       }
     ]
   },


### PR DESCRIPTION
**We will auto-merge this PR shortly. No action is required**

---

This PR adds a new `test_runner.average_run_time` key to the `config.json` file. The purpose of this field is allow the website to show a progress bar while the test runner runs. The average run time is defined in seconds with one digit of precision.

For more information, see https://github.com/exercism/docs/pull/130

We've pre-populated the average run time value by timing the execution time of the test runner in Docker on the example solution of the `leap` exercise, repeating that 4 more times, and then averaging the execution times. Clearly, the actual average execution time will differ between exercises and solutions, so this should be seen as very general indicator.

*This is mostly a stop-gap solution for now. We'll revisit this in 6 months time or so.* 

## Tracking

https://github.com/exercism/v3-launch/issues/35
