### PR TITLE
Collatz Conjecture: test for non-integers

### DIFF
--- a/exercises/practice/collatz-conjecture/.meta/proof.ci.ts
+++ b/exercises/practice/collatz-conjecture/.meta/proof.ci.ts
@@ -1,6 +1,6 @@
 export function steps(n: number): number {
-  if (n <= 0) {
-    throw new Error('Only positive numbers are allowed')
+  if (n <= 0 || !Number.isInteger(n)) {
+    throw new Error('Only positive integers are allowed')
   }
   return calculateStepsRecursively(n, 0)
 }

--- a/exercises/practice/collatz-conjecture/collatz-conjecture.test.ts
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture.test.ts
@@ -22,16 +22,23 @@ describe('CollatzConjecture', () => {
   })
 
   xit('zero is an error', () => {
-    const expected = 'Only positive numbers are allowed'
+    const expected = 'Only positive integers are allowed'
     expect(() => {
       steps(0)
     }).toThrowError(expected)
   })
 
   xit('negative value is an error', () => {
-    const expected = 'Only positive numbers are allowed'
+    const expected = 'Only positive integers are allowed'
     expect(() => {
       steps(-15)
+    }).toThrowError(expected)
+  })
+
+  xit('negative value is an error', () => {
+    const expected = 'Only positive integers are allowed'
+    expect(() => {
+      steps(3.1415)
     }).toThrowError(expected)
   })
 })

--- a/exercises/practice/collatz-conjecture/collatz-conjecture.test.ts
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture.test.ts
@@ -35,7 +35,7 @@ describe('CollatzConjecture', () => {
     }).toThrowError(expected)
   })
 
-  xit('negative value is an error', () => {
+  xit('non-integer value is an error', () => {
     const expected = 'Only positive integers are allowed'
     expect(() => {
       steps(3.1415)


### PR DESCRIPTION
The Collatz Conjecture holds only for positive integers. TypeScript does not have an integer type and therefore the input must be explicitly tested. 

Changes:
- Adds a test case for a positive non-integer
- Modifies the expected error message from 'Only positive numbers are allowed' to 'Only positive integers are allowed' so that the student can test the input using a single if statement