### PR TITLE
Exercise Palindrome Products - Changed test "smallest palindrome from four digit factors" to test.skip

### DIFF
--- a/exercises/practice/palindrome-products/palindrome-products.test.ts
+++ b/exercises/practice/palindrome-products/palindrome-products.test.ts
@@ -67,7 +67,7 @@ describe('Palindromes', () => {
     expect(sortFactors(largest.factors)).toEqual(expected.factors)
   })
 
-  xtest('smallest palindrome from four digit factors', () => {
+  test.skip('smallest palindrome from four digit factors', () => {
     const palindromes = generate({
       maxFactor: 9999,
       minFactor: 1000,


### PR DESCRIPTION
To address issue #741 