### PR TITLE
tournament: sync package.json dependencies

### DIFF
--- a/exercises/practice/tournament/package.json
+++ b/exercises/practice/tournament/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.1.0",
-    "@exercism/eslint-config-typescript": "^0.4.0",
+    "@exercism/eslint-config-typescript": "^0.4.1",
     "@types/jest": "^27.4.0",
     "@types/node": "^16.11.24",
     "babel-jest": "^27.5.1",


### PR DESCRIPTION
This fixes the CI: https://github.com/exercism/typescript/runs/5789774620?check_suite_focus=true
