### PR TITLE
Grade School: use a try-catch block on a supposed illegal operation within the test

### DIFF
--- a/exercises/practice/grade-school/grade-school.test.ts
+++ b/exercises/practice/grade-school/grade-school.test.ts
@@ -65,14 +65,18 @@ describe('School', () => {
   xit('roster cannot be modified outside of module', () => {
     school.add('Aimee', 2)
     const roster = school.roster()
-    try { roster[2].push('Oops.') } catch {}
+    try {
+      roster[2].push('Oops.')
+    } catch {}
     const expectedDb = { 2: ['Aimee'] }
     expect(school.roster()).toEqual(expectedDb)
   })
 
   xit('roster cannot be modified outside of module using grade()', () => {
     school.add('Aimee', 2)
-    try { school.grade(2).push('Oops.') } catch {}
+    try {
+      school.grade(2).push('Oops.')
+    } catch {}
     const expectedDb = { 2: ['Aimee'] }
     expect(school.roster()).toEqual(expectedDb)
   })

--- a/exercises/practice/grade-school/grade-school.test.ts
+++ b/exercises/practice/grade-school/grade-school.test.ts
@@ -65,14 +65,14 @@ describe('School', () => {
   xit('roster cannot be modified outside of module', () => {
     school.add('Aimee', 2)
     const roster = school.roster()
-    roster[2].push('Oops.')
+    try { roster[2].push('Oops.') } catch {}
     const expectedDb = { 2: ['Aimee'] }
     expect(school.roster()).toEqual(expectedDb)
   })
 
   xit('roster cannot be modified outside of module using grade()', () => {
     school.add('Aimee', 2)
-    school.grade(2).push('Oops.')
+    try { school.grade(2).push('Oops.') } catch {}
     const expectedDb = { 2: ['Aimee'] }
     expect(school.roster()).toEqual(expectedDb)
   })


### PR DESCRIPTION
Fixes #1071