### PR TITLE
Hello World: Instructions: Installation Guide

### DIFF
--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -5,7 +5,7 @@
 Go through the setup instructions for TypeScript to
 install the necessary dependencies:
 
-http://exercism.org/languages/typescript
+[https://exercism.org/docs/tracks/typescript/installation](https://exercism.org/docs/tracks/typescript/installation)
 
 ## Requirements
 


### PR DESCRIPTION
Minor change to keep the instructions up to date 🤓

The existing link points to the Track overview page: http://exercism.org/languages/typescript
The instructions to install the dependencies for this track are actually located at this url: https://exercism.org/docs/tracks/typescript/installation

Plus the original link wasn't formatted as an actual markdown link.