### PR TITLE
Resistor Color Duo: fixing test case

### DIFF
--- a/exercises/practice/resistor-color-duo/resistor-color-duo.test.ts
+++ b/exercises/practice/resistor-color-duo/resistor-color-duo.test.ts
@@ -18,6 +18,6 @@ describe('Resistor Colors', () => {
   })
 
   xit('Ignore additional colors', () => {
-    expect(decodedValue(['green', 'brown', 'orange'])).toEqual(51)
+    expect(decodedValue(['green', 'brown', 'purple'])).toEqual(51)
   })
 })


### PR DESCRIPTION
Since all 3 colors are in [the color map](https://github.com/exercism/typescript/blob/main/exercises/practice/resistor-color-duo/.docs/instructions.md) - the result will be `513`, but not `51`.

Suggested solution - add a random color not mentioned in the description.