### PR TITLE
Update examples of the env var ASSIGNMENT usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,15 +69,15 @@ If there is no such issue, you may open one. The baseline of work is as follows:
 1. Open a new issue, we'll label it with `new exercise ✨`
 1. We'll assign the issue to you, so you get to work on this exercise
 1. Create a new folder in `/exercises`
-1. You'll need to sync this folder with the matching config files. You can use `sync` to do this: `ASSIGNMENT=slug yarn babel-node scripts/sync`.
+1. You'll need to sync this folder with the matching config files. You can use `sync` to do this: `ASSIGNMENT=practice/slug yarn babel-node scripts/sync`.
 1. Create a `<slug>.ts` stub file.
 1. Create a `<slug>.test.ts` test file. Here add the tests, per canonical data if possible (more on canonical data below).
 1. Create a `.meta/proof.ci.ts` file. Place a working implementation, assuming it's renamed to `<slug>.ts`
 1. Create `.meta/tests.toml`. If the exercise that is being implemented has test data in the [problem specifications repository][problem-specifications], the contents of this file **must** be a list of UUIDs of the tests that are implemented or not implemented. Scroll down to [tools](#tools) to find the configlet application which aids generating this file _interactively_.
 1. Create a `.meta/config.json`. Copy the structure from any other `.meta/config.json`. Fill the `blurb`, `source` and `source_url` according to the `metadata.yml` in the [problem specifications repository][problem-specifications]. Add yourself as author.
 1. Create a `.docs/instructions.md` file. Copy the instructions from the [problem specifications repository][problem-specifications]
-1. Run the tests locally, using `scripts/test`: `ASSIGNMENT=slug yarn babel-node scripts/test`.
-1. Run the linter locally, using `scripts/lint`: `ASSIGNMENT=slug yarn babel-node scripts/lint`.
+1. Run the tests locally, using `scripts/test`: `ASSIGNMENT=practice/slug yarn babel-node scripts/test`.
+1. Run the linter locally, using `scripts/lint`: `ASSIGNMENT=practice/slug yarn babel-node scripts/lint`.
 1. Create an entry in `config.json`: a unique _new_ UUID (you can use the `configlet uuid` tool to generate one, scroll down to [tools](#tools) to see how you can get it), give it a difficulty (should be similar to similar exercises), and make sure the _order_ of the file is sane. Currently the file is ordered first on core - non core, then on difficulty low to high, and finally lexographically.
 1. Format the files, using `scripts/format`: `yarn babel-node scripts/format`.
 
@@ -209,7 +209,7 @@ Use this action to format all the files using the correct version of prettier. I
 If the `ASSIGNMENT` environment variable is set, only _that_ exercise is tested. For example, if you only want to lint `two-fer`, you may, depending on your environment use:
 
 ```shell
-ASSIGNMENT=two-fer yarn babel-node scripts/lint
+ASSIGNMENT=practice/two-fer yarn babel-node scripts/lint
 ```
 
 #### `test`
@@ -231,7 +231,7 @@ ASSIGNMENT=two-fer yarn babel-node scripts/lint
 If the `ASSIGNMENT` environment variable is set, only _that_ exercise is tested. For example, if you only want to test the `example.js` for `two-fer`, you may, depending on your environment, use:
 
 ```shell
-ASSIGNMENT=two-fer yarn babel-node scripts/test
+ASSIGNMENT=practice/two-fer yarn babel-node scripts/test
 ```
 
 #### `sync`
@@ -256,7 +256,7 @@ ASSIGNMENT=two-fer yarn babel-node scripts/test
 If the `ASSIGNMENT` environment variable is set, only _that_ exercise is tested. For example, if you only want to sync the files for `two-fer`, you may, depending on your environment, use:
 
 ```shell
-ASSIGNMENT=two-fer yarn babel-node scripts/sync
+ASSIGNMENT=practice/two-fer yarn babel-node scripts/sync
 ```
 
 #### `checksum`

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ If the `ASSIGNMENT` environment variable is set, only _that_ exercise is tested.
 For example, if you only want to test the `two-fer.example.ts` for `two-fer`, you may, depending on your environment, use:
 
 ```shell
-ASSIGNMENT=two-fer yarn babel-node scripts/test
+ASSIGNMENT=practice/two-fer yarn babel-node scripts/test
 ```
 
 > Running on Windows? Depending on your shell, environment variables are set differently.
 > You can use `cross-env` to normalize this. The following should work across environments:
 >
 > ```bash
-> yarn cross-env ASSIGNMENT=two-fer babel-node scripts/test
+> yarn cross-env ASSIGNMENT=practice/two-fer babel-node scripts/test
 > ```
 
 ## Related repositories


### PR DESCRIPTION
As I was working on my previous PR, I noticed the examples of how to run tests only for one exercise were slightly wrong in how to use the `ASSIGNMENT` env var.