### PR TITLE
Sync rational-numbers; Don't use strict equality when comparing floats

### DIFF
--- a/exercises/practice/rational-numbers/.docs/instructions.md
+++ b/exercises/practice/rational-numbers/.docs/instructions.md
@@ -2,6 +2,12 @@
 
 A rational number is defined as the quotient of two integers `a` and `b`, called the numerator and denominator, respectively, where `b != 0`.
 
+```exercism/note
+Note that mathematically, the denominator can't be zero.
+However in many implementations of rational numbers, you will find that the denominator is allowed to be zero with behaviour similar to positive or negative infinity in floating point numbers.
+In those cases, the denominator and numerator generally still can't both be zero at once.
+```
+
 The absolute value `|r|` of the rational number `r = a/b` is equal to `|a|/|b|`.
 
 The sum of two rational numbers `r₁ = a₁/b₁` and `r₂ = a₂/b₂` is `r₁ + r₂ = a₁/b₁ + a₂/b₂ = (a₁ * b₂ + a₂ * b₁) / (b₁ * b₂)`.
@@ -25,6 +31,12 @@ Implement the following operations:
 - addition, subtraction, multiplication and division of two rational numbers,
 - absolute value, exponentiation of a given rational number to an integer power, exponentiation of a given rational number to a real (floating-point) power, exponentiation of a real number to a rational number.
 
-Your implementation of rational numbers should always be reduced to lowest terms. For example, `4/4` should reduce to `1/1`, `30/60` should reduce to `1/2`, `12/8` should reduce to `3/2`, etc. To reduce a rational number `r = a/b`, divide `a` and `b` by the greatest common divisor (gcd) of `a` and `b`. So, for example, `gcd(12, 8) = 4`, so `r = 12/8` can be reduced to `(12/4)/(8/4) = 3/2`.
+Your implementation of rational numbers should always be reduced to lowest terms.
+For example, `4/4` should reduce to `1/1`, `30/60` should reduce to `1/2`, `12/8` should reduce to `3/2`, etc.
+To reduce a rational number `r = a/b`, divide `a` and `b` by the greatest common divisor (gcd) of `a` and `b`.
+So, for example, `gcd(12, 8) = 4`, so `r = 12/8` can be reduced to `(12/4)/(8/4) = 3/2`.
+The reduced form of a rational number should be in "standard form" (the denominator should always be a positive integer).
+If a denominator with a negative integer is present, multiply both numerator and denominator by `-1` to ensure standard form is reached.
+For example, `3/-4` should be reduced to `-3/4`
 
 Assume that the programming language you are using does not have an implementation of rational numbers.

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -4,7 +4,8 @@
   ],
   "contributors": [
     "masters3d",
-    "SleeplessByte"
+    "SleeplessByte",
+    "angelikatyborska"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/rational-numbers/.meta/proof.ci.ts
+++ b/exercises/practice/rational-numbers/.meta/proof.ci.ts
@@ -49,10 +49,17 @@ export class Rational {
   }
 
   public exprational(n: number): Rational {
-    return new Rational(
-      Math.pow(this.numerator, n),
-      Math.pow(this.denominator, n)
-    )
+    if (n > 0) {
+      return new Rational(
+        Math.pow(this.numerator, n),
+        Math.pow(this.denominator, n)
+      )
+    } else {
+      return new Rational(
+        Math.pow(this.denominator, Math.abs(n)),
+        Math.pow(this.numerator, Math.abs(n))
+      )
+    }
   }
 
   public expreal(base: number): number {

--- a/exercises/practice/rational-numbers/.meta/proof.ci.ts
+++ b/exercises/practice/rational-numbers/.meta/proof.ci.ts
@@ -1,6 +1,6 @@
 export class Rational {
-  private numerator: number
-  private denominator: number
+  public numerator: number
+  public denominator: number
 
   constructor(numerator: number, denominator: number) {
     if (denominator === 0) {

--- a/exercises/practice/rational-numbers/.meta/tests.toml
+++ b/exercises/practice/rational-numbers/.meta/tests.toml
@@ -1,117 +1,139 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [0ba4d988-044c-4ed5-9215-4d0bb8d0ae9f]
-description = "Add two positive rational numbers"
+description = "Arithmetic -> Addition -> Add two positive rational numbers"
 
 [88ebc342-a2ac-4812-a656-7b664f718b6a]
-description = "Add a positive rational number and a negative rational number"
+description = "Arithmetic -> Addition -> Add a positive rational number and a negative rational number"
 
 [92ed09c2-991e-4082-a602-13557080205c]
-description = "Add two negative rational numbers"
+description = "Arithmetic -> Addition -> Add two negative rational numbers"
 
 [6e58999e-3350-45fb-a104-aac7f4a9dd11]
-description = "Add a rational number to its additive inverse"
+description = "Arithmetic -> Addition -> Add a rational number to its additive inverse"
 
 [47bba350-9db1-4ab9-b412-4a7e1f72a66e]
-description = "Subtract two positive rational numbers"
+description = "Arithmetic -> Subtraction -> Subtract two positive rational numbers"
 
 [93926e2a-3e82-4aee-98a7-fc33fb328e87]
-description = "Subtract a positive rational number and a negative rational number"
+description = "Arithmetic -> Subtraction -> Subtract a positive rational number and a negative rational number"
 
 [a965ba45-9b26-442b-bdc7-7728e4b8d4cc]
-description = "Subtract two negative rational numbers"
+description = "Arithmetic -> Subtraction -> Subtract two negative rational numbers"
 
 [0df0e003-f68e-4209-8c6e-6a4e76af5058]
-description = "Subtract a rational number from itself"
+description = "Arithmetic -> Subtraction -> Subtract a rational number from itself"
 
 [34fde77a-75f4-4204-8050-8d3a937958d3]
-description = "Multiply two positive rational numbers"
+description = "Arithmetic -> Multiplication -> Multiply two positive rational numbers"
 
 [6d015cf0-0ea3-41f1-93de-0b8e38e88bae]
-description = "Multiply a negative rational number by a positive rational number"
+description = "Arithmetic -> Multiplication -> Multiply a negative rational number by a positive rational number"
 
 [d1bf1b55-954e-41b1-8c92-9fc6beeb76fa]
-description = "Multiply two negative rational numbers"
+description = "Arithmetic -> Multiplication -> Multiply two negative rational numbers"
 
 [a9b8f529-9ec7-4c79-a517-19365d779040]
-description = "Multiply a rational number by its reciprocal"
+description = "Arithmetic -> Multiplication -> Multiply a rational number by its reciprocal"
 
 [d89d6429-22fa-4368-ab04-9e01a44d3b48]
-description = "Multiply a rational number by 1"
+description = "Arithmetic -> Multiplication -> Multiply a rational number by 1"
 
 [0d95c8b9-1482-4ed7-bac9-b8694fa90145]
-description = "Multiply a rational number by 0"
+description = "Arithmetic -> Multiplication -> Multiply a rational number by 0"
 
 [1de088f4-64be-4e6e-93fd-5997ae7c9798]
-description = "Divide two positive rational numbers"
+description = "Arithmetic -> Division -> Divide two positive rational numbers"
 
 [7d7983db-652a-4e66-981a-e921fb38d9a9]
-description = "Divide a positive rational number by a negative rational number"
+description = "Arithmetic -> Division -> Divide a positive rational number by a negative rational number"
 
 [1b434d1b-5b38-4cee-aaf5-b9495c399e34]
-description = "Divide two negative rational numbers"
+description = "Arithmetic -> Division -> Divide two negative rational numbers"
 
 [d81c2ebf-3612-45a6-b4e0-f0d47812bd59]
-description = "Divide a rational number by 1"
+description = "Arithmetic -> Division -> Divide a rational number by 1"
 
 [5fee0d8e-5955-4324-acbe-54cdca94ddaa]
-description = "Absolute value of a positive rational number"
+description = "Absolute value -> Absolute value of a positive rational number"
 
 [3cb570b6-c36a-4963-a380-c0834321bcaa]
-description = "Absolute value of a positive rational number with negative numerator and denominator"
+description = "Absolute value -> Absolute value of a positive rational number with negative numerator and denominator"
 
 [6a05f9a0-1f6b-470b-8ff7-41af81773f25]
-description = "Absolute value of a negative rational number"
+description = "Absolute value -> Absolute value of a negative rational number"
 
 [5d0f2336-3694-464f-8df9-f5852fda99dd]
-description = "Absolute value of a negative rational number with negative denominator"
+description = "Absolute value -> Absolute value of a negative rational number with negative denominator"
 
 [f8e1ed4b-9dca-47fb-a01e-5311457b3118]
-description = "Absolute value of zero"
+description = "Absolute value -> Absolute value of zero"
+
+[4a8c939f-f958-473b-9f88-6ad0f83bb4c4]
+description = "Absolute value -> Absolute value of a rational number is reduced to lowest terms"
 
 [ea2ad2af-3dab-41e7-bb9f-bd6819668a84]
-description = "Raise a positive rational number to a positive integer power"
+description = "Exponentiation of a rational number -> Raise a positive rational number to a positive integer power"
 
 [8168edd2-0af3-45b1-b03f-72c01332e10a]
-description = "Raise a negative rational number to a positive integer power"
+description = "Exponentiation of a rational number -> Raise a negative rational number to a positive integer power"
+
+[c291cfae-cfd8-44f5-aa6c-b175c148a492]
+description = "Exponentiation of a rational number -> Raise a positive rational number to a negative integer power"
+
+[45cb3288-4ae4-4465-9ae5-c129de4fac8e]
+description = "Exponentiation of a rational number -> Raise a negative rational number to an even negative integer power"
+
+[2d47f945-ffe1-4916-a399-c2e8c27d7f72]
+description = "Exponentiation of a rational number -> Raise a negative rational number to an odd negative integer power"
 
 [e2f25b1d-e4de-4102-abc3-c2bb7c4591e4]
-description = "Raise zero to an integer power"
+description = "Exponentiation of a rational number -> Raise zero to an integer power"
 
 [431cac50-ab8b-4d58-8e73-319d5404b762]
-description = "Raise one to an integer power"
+description = "Exponentiation of a rational number -> Raise one to an integer power"
 
 [7d164739-d68a-4a9c-b99f-dd77ce5d55e6]
-description = "Raise a positive rational number to the power of zero"
+description = "Exponentiation of a rational number -> Raise a positive rational number to the power of zero"
 
 [eb6bd5f5-f880-4bcd-8103-e736cb6e41d1]
-description = "Raise a negative rational number to the power of zero"
+description = "Exponentiation of a rational number -> Raise a negative rational number to the power of zero"
 
 [30b467dd-c158-46f5-9ffb-c106de2fd6fa]
-description = "Raise a real number to a positive rational number"
+description = "Exponentiation of a real number to a rational number -> Raise a real number to a positive rational number"
 
 [6e026bcc-be40-4b7b-ae22-eeaafc5a1789]
-description = "Raise a real number to a negative rational number"
+description = "Exponentiation of a real number to a rational number -> Raise a real number to a negative rational number"
 
 [9f866da7-e893-407f-8cd2-ee85d496eec5]
-description = "Raise a real number to a zero rational number"
+description = "Exponentiation of a real number to a rational number -> Raise a real number to a zero rational number"
 
 [0a63fbde-b59c-4c26-8237-1e0c73354d0a]
-description = "Reduce a positive rational number to lowest terms"
+description = "Reduction to lowest terms -> Reduce a positive rational number to lowest terms"
+
+[5ed6f248-ad8d-4d4e-a545-9146c6727f33]
+description = "Reduction to lowest terms -> Reduce places the minus sign on the numerator"
 
 [f87c2a4e-d29c-496e-a193-318c503e4402]
-description = "Reduce a negative rational number to lowest terms"
+description = "Reduction to lowest terms -> Reduce a negative rational number to lowest terms"
 
 [3b92ffc0-5b70-4a43-8885-8acee79cdaaf]
-description = "Reduce a rational number with a negative denominator to lowest terms"
+description = "Reduction to lowest terms -> Reduce a rational number with a negative denominator to lowest terms"
 
 [c9dbd2e6-5ac0-4a41-84c1-48b645b4f663]
-description = "Reduce zero to lowest terms"
+description = "Reduction to lowest terms -> Reduce zero to lowest terms"
 
 [297b45ad-2054-4874-84d4-0358dc1b8887]
-description = "Reduce an integer to lowest terms"
+description = "Reduction to lowest terms -> Reduce an integer to lowest terms"
 
 [a73a17fe-fe8c-4a1c-a63b-e7579e333d9e]
-description = "Reduce one to lowest terms"
+description = "Reduction to lowest terms -> Reduce one to lowest terms"

--- a/exercises/practice/rational-numbers/rational-numbers.test.ts
+++ b/exercises/practice/rational-numbers/rational-numbers.test.ts
@@ -150,17 +150,17 @@ describe('Exponentiation of a rational number', () => {
 describe('Exponentiation of a real number to a rational number', () => {
   xit('Raise a real number to a positive rational number', () => {
     const expected = 16.0
-    expect(new Rational(4, 3).expreal(8)).toEqual(expected)
+    expect(new Rational(4, 3).expreal(8)).toBeCloseTo(expected, 10)
   })
 
   xit('Raise a real number to a negative rational number', () => {
     const expected = 1.0 / 3.0
-    expect(new Rational(-1, 2).expreal(9)).toBeCloseTo(expected, 15)
+    expect(new Rational(-1, 2).expreal(9)).toBeCloseTo(expected, 10)
   })
 
   xit('Raise a real number to a zero rational number', () => {
     const expected = 1.0
-    expect(new Rational(0, 1).expreal(2)).toEqual(expected)
+    expect(new Rational(0, 1).expreal(2)).toBeCloseTo(expected, 10)
   })
 })
 

--- a/exercises/practice/rational-numbers/rational-numbers.test.ts
+++ b/exercises/practice/rational-numbers/rational-numbers.test.ts
@@ -5,7 +5,7 @@ function assertSameRational(r1: Rational, r2: Rational): void {
   expect(r1.denominator).toEqual(r2.denominator)
 }
 
-describe ('Constructor', () => {
+describe('Constructor', () => {
   it('Assigns public fields numerator and denominator', () => {
     const rational = new Rational(5, 7)
     expect(rational.numerator).toEqual(5)

--- a/exercises/practice/rational-numbers/rational-numbers.test.ts
+++ b/exercises/practice/rational-numbers/rational-numbers.test.ts
@@ -1,288 +1,241 @@
 import { Rational } from './rational-numbers'
 
-function assertSameRational(r1: Rational, r2: Rational): void {
-  expect(r1.numerator).toEqual(r2.numerator)
-  expect(r1.denominator).toEqual(r2.denominator)
+function assertRational(
+  actual: Rational,
+  expectedNumerator: number,
+  expectedDenominator: number
+): void {
+  expect(actual.numerator).toEqual(expectedNumerator)
+  expect(actual.denominator).toEqual(expectedDenominator)
 }
 
-describe('Constructor', () => {
-  it('Assigns public fields numerator and denominator', () => {
-    const rational = new Rational(5, 7)
-    expect(rational.numerator).toEqual(5)
-    expect(rational.denominator).toEqual(7)
-  })
-})
-
 describe('Addition', () => {
-  xit('Add two positive rational numbers', () => {
+  it('Add two positive rational numbers', () => {
     const actual = new Rational(1, 2).add(new Rational(2, 3))
-    const expected = new Rational(7, 6)
-    assertSameRational(actual, expected)
+    assertRational(actual, 7, 6)
   })
 
   xit('Add a positive rational number and a negative rational number', () => {
     const actual = new Rational(1, 2).add(new Rational(-2, 3))
-    const expected = new Rational(-1, 6)
-    assertSameRational(actual, expected)
+    assertRational(actual, -1, 6)
   })
 
   xit('Add two negative rational numbers', () => {
     const actual = new Rational(-1, 2).add(new Rational(-2, 3))
-    const expected = new Rational(-7, 6)
-    assertSameRational(actual, expected)
+    assertRational(actual, -7, 6)
   })
 
   xit('Add a rational number to its additive inverse', () => {
     const actual = new Rational(1, 2).add(new Rational(-1, 2))
-    const expected = new Rational(0, 1)
-    assertSameRational(actual, expected)
+    assertRational(actual, 0, 1)
   })
 })
 
 describe('Subtraction', () => {
   xit('Subtract two positive rational numbers', () => {
     const actual = new Rational(1, 2).sub(new Rational(2, 3))
-    const expected = new Rational(-1, 6)
-    assertSameRational(actual, expected)
+    assertRational(actual, -1, 6)
   })
 
   xit('Subtract a positive rational number and a negative rational number', () => {
     const actual = new Rational(1, 2).sub(new Rational(-2, 3))
-    const expected = new Rational(7, 6)
-    assertSameRational(actual, expected)
+    assertRational(actual, 7, 6)
   })
 
   xit('Subtract two negative rational numbers', () => {
     const actual = new Rational(-1, 2).sub(new Rational(-2, 3))
-    const expected = new Rational(1, 6)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 6)
   })
 
   xit('Subtract a rational number from itself', () => {
     const actual = new Rational(1, 2).sub(new Rational(1, 2))
-    const expected = new Rational(0, 1)
-    assertSameRational(actual, expected)
+    assertRational(actual, 0, 1)
   })
 })
 
 describe('Multiplication', () => {
   xit('Multiply two positive rational numbers', () => {
     const actual = new Rational(1, 2).mul(new Rational(2, 3))
-    const expected = new Rational(1, 3)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 3)
   })
 
   xit('Multiply a negative rational number by a positive rational number', () => {
     const actual = new Rational(-1, 2).mul(new Rational(2, 3))
-    const expected = new Rational(-1, 3)
-    assertSameRational(actual, expected)
+    assertRational(actual, -1, 3)
   })
 
   xit('Multiply two negative rational numbers', () => {
     const actual = new Rational(-1, 2).mul(new Rational(-2, 3))
-    const expected = new Rational(1, 3)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 3)
   })
 
   xit('Multiply a rational number by its reciprocal', () => {
     const actual = new Rational(1, 2).mul(new Rational(2, 1))
-    const expected = new Rational(1, 1)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 1)
   })
 
   xit('Multiply a rational number by 1', () => {
     const actual = new Rational(1, 2).mul(new Rational(1, 1))
-    const expected = new Rational(1, 2)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 2)
   })
 
   xit('Multiply a rational number by 0', () => {
     const actual = new Rational(1, 2).mul(new Rational(0, 1))
-    const expected = new Rational(0, 1)
-    assertSameRational(actual, expected)
+    assertRational(actual, 0, 1)
   })
 })
 
 describe('Division', () => {
   xit('Divide two positive rational numbers', () => {
     const actual = new Rational(1, 2).div(new Rational(2, 3))
-    const expected = new Rational(3, 4)
-    assertSameRational(actual, expected)
+    assertRational(actual, 3, 4)
   })
 
   xit('Divide a positive rational number by a negative rational number', () => {
     const actual = new Rational(1, 2).div(new Rational(-2, 3))
-    const expected = new Rational(-3, 4)
-    assertSameRational(actual, expected)
+    assertRational(actual, -3, 4)
   })
 
   xit('Divide two negative rational numbers', () => {
     const actual = new Rational(-1, 2).div(new Rational(-2, 3))
-    const expected = new Rational(3, 4)
-    assertSameRational(actual, expected)
+    assertRational(actual, 3, 4)
   })
 
   xit('Divide a rational number by 1', () => {
     const actual = new Rational(1, 2).div(new Rational(1, 1))
-    const expected = new Rational(1, 2)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 2)
   })
 })
 
 describe('Absolute value', () => {
   xit('Absolute value of a positive rational number', () => {
     const actual = new Rational(1, 2).abs()
-    const expected = new Rational(1, 2)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 2)
   })
 
   xit('Absolute value of a positive rational number with negative numerator and denominator', () => {
     const actual = new Rational(-1, -2).abs()
-    const expected = new Rational(1, 2)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 2)
   })
 
   xit('Absolute value of a negative rational number', () => {
     const actual = new Rational(-1, 2).abs()
-    const expected = new Rational(1, 2)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 2)
   })
 
   xit('Absolute value of a negative rational number with negative denominator', () => {
     const actual = new Rational(1, -2).abs()
-    const expected = new Rational(1, 2)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 2)
   })
 
   xit('Absolute value of zero', () => {
     const actual = new Rational(0, 1).abs()
-    const expected = new Rational(0, 1)
-    assertSameRational(actual, expected)
+    assertRational(actual, 0, 1)
   })
 
   xit('Absolute value of a rational number is reduced to lowest terms', () => {
     const actual = new Rational(2, 4).abs()
-    const expected = new Rational(1, 2)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 2)
   })
 })
 
 describe('Exponentiation of a rational number', () => {
   xit('Raise a positive rational number to a positive integer power', () => {
     const actual = new Rational(1, 2).exprational(3)
-    const expected = new Rational(1, 8)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 8)
   })
 
   xit('Raise a negative rational number to a positive integer power', () => {
     const actual = new Rational(-1, 2).exprational(3)
-    const expected = new Rational(-1, 8)
-    assertSameRational(actual, expected)
+    assertRational(actual, -1, 8)
   })
 
   xit('Raise a positive rational number to a negative integer power', () => {
     const actual = new Rational(3, 5).exprational(-2)
-    const expected = new Rational(25, 9)
-    assertSameRational(actual, expected)
+    assertRational(actual, 25, 9)
   })
 
   xit('Raise a negative rational number to an even negative integer power', () => {
     const actual = new Rational(-3, 5).exprational(-2)
-    const expected = new Rational(25, 9)
-    assertSameRational(actual, expected)
+    assertRational(actual, 25, 9)
   })
 
   xit('Raise a negative rational number to an odd negative integer power', () => {
     const actual = new Rational(-3, 5).exprational(-3)
-    const expected = new Rational(-125, 27)
-    assertSameRational(actual, expected)
+    assertRational(actual, -125, 27)
   })
 
   xit('Raise zero to an integer power', () => {
     const actual = new Rational(0, 1).exprational(5)
-    const expected = new Rational(0, 1)
-    assertSameRational(actual, expected)
+    assertRational(actual, 0, 1)
   })
 
   xit('Raise one to an integer power', () => {
     const actual = new Rational(1, 1).exprational(4)
-    const expected = new Rational(1, 1)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 1)
   })
 
   xit('Raise a positive rational number to the power of zero', () => {
     const actual = new Rational(1, 2).exprational(0)
-    const expected = new Rational(1, 1)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 1)
   })
 
   xit('Raise a negative rational number to the power of zero', () => {
     const actual = new Rational(-1, 2).exprational(0)
-    const expected = new Rational(1, 1)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 1)
   })
 })
 
 describe('Exponentiation of a real number to a rational number', () => {
   xit('Raise a real number to a positive rational number', () => {
     const actual = new Rational(4, 3).expreal(8)
-    const expected = 16.0
-    expect(actual).toBeCloseTo(expected, 10)
+    expect(actual).toBeCloseTo(16.0, 10)
   })
 
   xit('Raise a real number to a negative rational number', () => {
     const actual = new Rational(-1, 2).expreal(9)
-    const expected = 1.0 / 3.0
-    expect(actual).toBeCloseTo(expected, 10)
+    expect(actual).toBeCloseTo(1.0 / 3.0, 10)
   })
 
   xit('Raise a real number to a zero rational number', () => {
     const actual = new Rational(0, 1).expreal(2)
-    const expected = 1.0
-    expect(actual).toBeCloseTo(expected, 10)
+    expect(actual).toBeCloseTo(1.0, 10)
   })
 })
 
 describe('Reduction to lowest terms', () => {
   xit('Reduce a positive rational number to lowest terms', () => {
     const actual = new Rational(2, 4).reduce()
-    const expected = new Rational(1, 2)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 2)
   })
 
   xit('Reduce places the minus sign on the numerator', () => {
     const actual = new Rational(3, -4).reduce()
-    const expected = new Rational(-3, 4)
-    assertSameRational(actual, expected)
+    assertRational(actual, -3, 4)
   })
 
   xit('Reduce a negative rational number to lowest terms', () => {
     const actual = new Rational(-4, 6).reduce()
-    const expected = new Rational(-2, 3)
-    assertSameRational(actual, expected)
+    assertRational(actual, -2, 3)
   })
 
   xit('Reduce a rational number with a negative denominator to lowest terms', () => {
     const actual = new Rational(3, -9).reduce()
-    const expected = new Rational(-1, 3)
-    assertSameRational(actual, expected)
+    assertRational(actual, -1, 3)
   })
 
   xit('Reduce zero to lowest terms', () => {
     const actual = new Rational(0, 6).reduce()
-    const expected = new Rational(0, 1)
-    assertSameRational(actual, expected)
+    assertRational(actual, 0, 1)
   })
 
   xit('Reduce an integer to lowest terms', () => {
     const actual = new Rational(-14, 7).reduce()
-    const expected = new Rational(-2, 1)
-    assertSameRational(actual, expected)
+    assertRational(actual, -2, 1)
   })
 
   xit('Reduce one to lowest terms', () => {
     const actual = new Rational(13, 13).reduce()
-    const expected = new Rational(1, 1)
-    assertSameRational(actual, expected)
+    assertRational(actual, 1, 1)
   })
 })

--- a/exercises/practice/rational-numbers/rational-numbers.test.ts
+++ b/exercises/practice/rational-numbers/rational-numbers.test.ts
@@ -1,232 +1,288 @@
 import { Rational } from './rational-numbers'
 
+function assertSameRational(r1: Rational, r2: Rational): void {
+  expect(r1.numerator).toEqual(r2.numerator)
+  expect(r1.denominator).toEqual(r2.denominator)
+}
+
+describe ('Constructor', () => {
+  it('Assigns public fields numerator and denominator', () => {
+    const rational = new Rational(5, 7)
+    expect(rational.numerator).toEqual(5)
+    expect(rational.denominator).toEqual(7)
+  })
+})
+
 describe('Addition', () => {
-  it('Add two positive rational numbers', () => {
+  xit('Add two positive rational numbers', () => {
+    const actual = new Rational(1, 2).add(new Rational(2, 3))
     const expected = new Rational(7, 6)
-    expect(new Rational(1, 2).add(new Rational(2, 3))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Add a positive rational number and a negative rational number', () => {
+    const actual = new Rational(1, 2).add(new Rational(-2, 3))
     const expected = new Rational(-1, 6)
-    expect(new Rational(1, 2).add(new Rational(-2, 3))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Add two negative rational numbers', () => {
+    const actual = new Rational(-1, 2).add(new Rational(-2, 3))
     const expected = new Rational(-7, 6)
-    expect(new Rational(-1, 2).add(new Rational(-2, 3))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Add a rational number to its additive inverse', () => {
+    const actual = new Rational(1, 2).add(new Rational(-1, 2))
     const expected = new Rational(0, 1)
-    expect(new Rational(1, 2).add(new Rational(-1, 2))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 })
 
 describe('Subtraction', () => {
   xit('Subtract two positive rational numbers', () => {
+    const actual = new Rational(1, 2).sub(new Rational(2, 3))
     const expected = new Rational(-1, 6)
-    expect(new Rational(1, 2).sub(new Rational(2, 3))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Subtract a positive rational number and a negative rational number', () => {
+    const actual = new Rational(1, 2).sub(new Rational(-2, 3))
     const expected = new Rational(7, 6)
-    expect(new Rational(1, 2).sub(new Rational(-2, 3))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Subtract two negative rational numbers', () => {
+    const actual = new Rational(-1, 2).sub(new Rational(-2, 3))
     const expected = new Rational(1, 6)
-    expect(new Rational(-1, 2).sub(new Rational(-2, 3))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Subtract a rational number from itself', () => {
+    const actual = new Rational(1, 2).sub(new Rational(1, 2))
     const expected = new Rational(0, 1)
-    expect(new Rational(1, 2).sub(new Rational(1, 2))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 })
 
 describe('Multiplication', () => {
   xit('Multiply two positive rational numbers', () => {
+    const actual = new Rational(1, 2).mul(new Rational(2, 3))
     const expected = new Rational(1, 3)
-    expect(new Rational(1, 2).mul(new Rational(2, 3))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Multiply a negative rational number by a positive rational number', () => {
+    const actual = new Rational(-1, 2).mul(new Rational(2, 3))
     const expected = new Rational(-1, 3)
-    expect(new Rational(-1, 2).mul(new Rational(2, 3))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Multiply two negative rational numbers', () => {
+    const actual = new Rational(-1, 2).mul(new Rational(-2, 3))
     const expected = new Rational(1, 3)
-    expect(new Rational(-1, 2).mul(new Rational(-2, 3))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Multiply a rational number by its reciprocal', () => {
+    const actual = new Rational(1, 2).mul(new Rational(2, 1))
     const expected = new Rational(1, 1)
-    expect(new Rational(1, 2).mul(new Rational(2, 1))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Multiply a rational number by 1', () => {
+    const actual = new Rational(1, 2).mul(new Rational(1, 1))
     const expected = new Rational(1, 2)
-    expect(new Rational(1, 2).mul(new Rational(1, 1))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Multiply a rational number by 0', () => {
+    const actual = new Rational(1, 2).mul(new Rational(0, 1))
     const expected = new Rational(0, 1)
-    expect(new Rational(1, 2).mul(new Rational(0, 1))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 })
 
 describe('Division', () => {
   xit('Divide two positive rational numbers', () => {
+    const actual = new Rational(1, 2).div(new Rational(2, 3))
     const expected = new Rational(3, 4)
-    expect(new Rational(1, 2).div(new Rational(2, 3))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Divide a positive rational number by a negative rational number', () => {
+    const actual = new Rational(1, 2).div(new Rational(-2, 3))
     const expected = new Rational(-3, 4)
-    expect(new Rational(1, 2).div(new Rational(-2, 3))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Divide two negative rational numbers', () => {
+    const actual = new Rational(-1, 2).div(new Rational(-2, 3))
     const expected = new Rational(3, 4)
-    expect(new Rational(-1, 2).div(new Rational(-2, 3))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Divide a rational number by 1', () => {
+    const actual = new Rational(1, 2).div(new Rational(1, 1))
     const expected = new Rational(1, 2)
-    expect(new Rational(1, 2).div(new Rational(1, 1))).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 })
 
 describe('Absolute value', () => {
   xit('Absolute value of a positive rational number', () => {
+    const actual = new Rational(1, 2).abs()
     const expected = new Rational(1, 2)
-    expect(new Rational(1, 2).abs()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Absolute value of a positive rational number with negative numerator and denominator', () => {
+    const actual = new Rational(-1, -2).abs()
     const expected = new Rational(1, 2)
-    expect(new Rational(-1, -2).abs()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Absolute value of a negative rational number', () => {
+    const actual = new Rational(-1, 2).abs()
     const expected = new Rational(1, 2)
-    expect(new Rational(-1, 2).abs()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Absolute value of a negative rational number with negative denominator', () => {
+    const actual = new Rational(1, -2).abs()
     const expected = new Rational(1, 2)
-    expect(new Rational(1, -2).abs()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Absolute value of zero', () => {
+    const actual = new Rational(0, 1).abs()
     const expected = new Rational(0, 1)
-    expect(new Rational(0, 1).abs()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Absolute value of a rational number is reduced to lowest terms', () => {
+    const actual = new Rational(2, 4).abs()
     const expected = new Rational(1, 2)
-    expect(new Rational(2, 4).abs()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 })
 
 describe('Exponentiation of a rational number', () => {
   xit('Raise a positive rational number to a positive integer power', () => {
+    const actual = new Rational(1, 2).exprational(3)
     const expected = new Rational(1, 8)
-    expect(new Rational(1, 2).exprational(3)).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Raise a negative rational number to a positive integer power', () => {
+    const actual = new Rational(-1, 2).exprational(3)
     const expected = new Rational(-1, 8)
-    expect(new Rational(-1, 2).exprational(3)).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Raise a positive rational number to a negative integer power', () => {
+    const actual = new Rational(3, 5).exprational(-2)
     const expected = new Rational(25, 9)
-    expect(new Rational(3, 5).exprational(-2)).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Raise a negative rational number to an even negative integer power', () => {
+    const actual = new Rational(-3, 5).exprational(-2)
     const expected = new Rational(25, 9)
-    expect(new Rational(-3, 5).exprational(-2)).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Raise a negative rational number to an odd negative integer power', () => {
+    const actual = new Rational(-3, 5).exprational(-3)
     const expected = new Rational(-125, 27)
-    expect(new Rational(-3, 5).exprational(-3)).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Raise zero to an integer power', () => {
+    const actual = new Rational(0, 1).exprational(5)
     const expected = new Rational(0, 1)
-    expect(new Rational(0, 1).exprational(5)).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Raise one to an integer power', () => {
+    const actual = new Rational(1, 1).exprational(4)
     const expected = new Rational(1, 1)
-    expect(new Rational(1, 1).exprational(4)).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Raise a positive rational number to the power of zero', () => {
+    const actual = new Rational(1, 2).exprational(0)
     const expected = new Rational(1, 1)
-    expect(new Rational(1, 2).exprational(0)).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Raise a negative rational number to the power of zero', () => {
+    const actual = new Rational(-1, 2).exprational(0)
     const expected = new Rational(1, 1)
-    expect(new Rational(-1, 2).exprational(0)).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 })
 
 describe('Exponentiation of a real number to a rational number', () => {
   xit('Raise a real number to a positive rational number', () => {
+    const actual = new Rational(4, 3).expreal(8)
     const expected = 16.0
-    expect(new Rational(4, 3).expreal(8)).toBeCloseTo(expected, 10)
+    expect(actual).toBeCloseTo(expected, 10)
   })
 
   xit('Raise a real number to a negative rational number', () => {
+    const actual = new Rational(-1, 2).expreal(9)
     const expected = 1.0 / 3.0
-    expect(new Rational(-1, 2).expreal(9)).toBeCloseTo(expected, 10)
+    expect(actual).toBeCloseTo(expected, 10)
   })
 
   xit('Raise a real number to a zero rational number', () => {
+    const actual = new Rational(0, 1).expreal(2)
     const expected = 1.0
-    expect(new Rational(0, 1).expreal(2)).toBeCloseTo(expected, 10)
+    expect(actual).toBeCloseTo(expected, 10)
   })
 })
 
 describe('Reduction to lowest terms', () => {
   xit('Reduce a positive rational number to lowest terms', () => {
+    const actual = new Rational(2, 4).reduce()
     const expected = new Rational(1, 2)
-    expect(new Rational(2, 4).reduce()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Reduce places the minus sign on the numerator', () => {
+    const actual = new Rational(3, -4).reduce()
     const expected = new Rational(-3, 4)
-    expect(new Rational(3, -4).reduce()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Reduce a negative rational number to lowest terms', () => {
+    const actual = new Rational(-4, 6).reduce()
     const expected = new Rational(-2, 3)
-    expect(new Rational(-4, 6).reduce()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Reduce a rational number with a negative denominator to lowest terms', () => {
+    const actual = new Rational(3, -9).reduce()
     const expected = new Rational(-1, 3)
-    expect(new Rational(3, -9).reduce()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Reduce zero to lowest terms', () => {
+    const actual = new Rational(0, 6).reduce()
     const expected = new Rational(0, 1)
-    expect(new Rational(0, 6).reduce()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Reduce an integer to lowest terms', () => {
+    const actual = new Rational(-14, 7).reduce()
     const expected = new Rational(-2, 1)
-    expect(new Rational(-14, 7).reduce()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 
   xit('Reduce one to lowest terms', () => {
+    const actual = new Rational(13, 13).reduce()
     const expected = new Rational(1, 1)
-    expect(new Rational(13, 13).reduce()).toEqual(expected)
+    assertSameRational(actual, expected)
   })
 })

--- a/exercises/practice/rational-numbers/rational-numbers.test.ts
+++ b/exercises/practice/rational-numbers/rational-numbers.test.ts
@@ -104,14 +104,29 @@ describe('Absolute value', () => {
     expect(new Rational(1, 2).abs()).toEqual(expected)
   })
 
+  xit('Absolute value of a positive rational number with negative numerator and denominator', () => {
+    const expected = new Rational(1, 2)
+    expect(new Rational(-1, -2).abs()).toEqual(expected)
+  })
+
   xit('Absolute value of a negative rational number', () => {
     const expected = new Rational(1, 2)
     expect(new Rational(-1, 2).abs()).toEqual(expected)
   })
 
+  xit('Absolute value of a negative rational number with negative denominator', () => {
+    const expected = new Rational(1, 2)
+    expect(new Rational(1, -2).abs()).toEqual(expected)
+  })
+
   xit('Absolute value of zero', () => {
     const expected = new Rational(0, 1)
     expect(new Rational(0, 1).abs()).toEqual(expected)
+  })
+
+  xit('Absolute value of a rational number is reduced to lowest terms', () => {
+    const expected = new Rational(1, 2)
+    expect(new Rational(2, 4).abs()).toEqual(expected)
   })
 })
 
@@ -124,6 +139,21 @@ describe('Exponentiation of a rational number', () => {
   xit('Raise a negative rational number to a positive integer power', () => {
     const expected = new Rational(-1, 8)
     expect(new Rational(-1, 2).exprational(3)).toEqual(expected)
+  })
+
+  xit('Raise a positive rational number to a negative integer power', () => {
+    const expected = new Rational(25, 9)
+    expect(new Rational(3, 5).exprational(-2)).toEqual(expected)
+  })
+
+  xit('Raise a negative rational number to an even negative integer power', () => {
+    const expected = new Rational(25, 9)
+    expect(new Rational(-3, 5).exprational(-2)).toEqual(expected)
+  })
+
+  xit('Raise a negative rational number to an odd negative integer power', () => {
+    const expected = new Rational(-125, 27)
+    expect(new Rational(-3, 5).exprational(-3)).toEqual(expected)
   })
 
   xit('Raise zero to an integer power', () => {
@@ -168,6 +198,11 @@ describe('Reduction to lowest terms', () => {
   xit('Reduce a positive rational number to lowest terms', () => {
     const expected = new Rational(1, 2)
     expect(new Rational(2, 4).reduce()).toEqual(expected)
+  })
+
+  xit('Reduce places the minus sign on the numerator', () => {
+    const expected = new Rational(-3, 4)
+    expect(new Rational(3, -4).reduce()).toEqual(expected)
   })
 
   xit('Reduce a negative rational number to lowest terms', () => {


### PR DESCRIPTION
~This PR makes rational-numbers up to date with problem specs, but also addresses part of https://github.com/exercism/typescript/issues/1049 complaining about the `expreal` function tests failing for some students because of strict float comparisons.

The PR doesn't address the first part of that issue because I wasn't sure which way you would like to take that problem. I can push more commits to address that too if I get some guidance about which way you would like to go 🙂 ~

Resolves https://github.com/exercism/typescript/issues/1049