### PR TITLE
Sync word-search

### DIFF
--- a/exercises/practice/word-search/.docs/instructions.md
+++ b/exercises/practice/word-search/.docs/instructions.md
@@ -1,7 +1,6 @@
 # Instructions
 
-In word search puzzles you get a square of letters and have to find specific
-words in them.
+In word search puzzles you get a square of letters and have to find specific words in them.
 
 For example:
 
@@ -20,8 +19,6 @@ clojurermt
 
 There are several programming languages hidden in the above square.
 
-Words can be hidden in all kinds of directions: left-to-right, right-to-left,
-vertical and diagonal.
+Words can be hidden in all kinds of directions: left-to-right, right-to-left, vertical and diagonal.
 
-Given a puzzle and a list of words return the location of the first and last
-letter of each word.
+Given a puzzle and a list of words return the location of the first and last letter of each word.

--- a/exercises/practice/word-search/.meta/tests.toml
+++ b/exercises/practice/word-search/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [b4057815-0d01-41f0-9119-6a91f54b2a0a]
 description = "Should accept an initial game grid and a target search word"
@@ -61,3 +68,15 @@ description = "Should locate words written top right to bottom left"
 
 [695531db-69eb-463f-8bad-8de3bf5ef198]
 description = "Should fail to locate a word that is not in the puzzle"
+
+[fda5b937-6774-4a52-8f89-f64ed833b175]
+description = "Should fail to locate words that are not on horizontal, vertical, or diagonal lines"
+
+[5b6198eb-2847-4e2f-8efe-65045df16bd3]
+description = "Should not concatenate different lines to find a horizontal word"
+
+[eba44139-a34f-4a92-98e1-bd5f259e5769]
+description = "Should not wrap around horizontally to find a word"
+
+[cd1f0fa8-76af-4167-b105-935f78364dac]
+description = "Should not wrap around vertically to find a word"

--- a/exercises/practice/word-search/word-search.test.ts
+++ b/exercises/practice/word-search/word-search.test.ts
@@ -1,14 +1,14 @@
 import { WordSearch } from './word-search'
 
 describe('single line grids', () => {
-  it('Should accept an initial game grid', () => {
+  it('should accept an initial game grid', () => {
     const grid = ['jefblpepre']
     const wordSearch = new WordSearch(grid)
 
     expect(wordSearch instanceof WordSearch).toEqual(true)
   })
 
-  xit('can accept a target search word', () => {
+  xit('should accept a target search word', () => {
     const grid = ['jefblpepre']
     const wordSearch = new WordSearch(grid)
 
@@ -28,7 +28,7 @@ describe('single line grids', () => {
     expect(wordSearch.find(['clojure'])).toEqual(expectedResults)
   })
 
-  xit('can locate a left to right word in a different position', () => {
+  xit('should locate the same word written left to right in a different position', () => {
     const grid = ['mtclojurer']
     const expectedResults = {
       clojure: {
@@ -41,7 +41,7 @@ describe('single line grids', () => {
     expect(wordSearch.find(['clojure'])).toEqual(expectedResults)
   })
 
-  xit('can locate a different left to right word', () => {
+  xit('should locate a different left to right word', () => {
     const grid = ['coffeelplx']
     const expectedResults = {
       coffee: {
@@ -53,7 +53,7 @@ describe('single line grids', () => {
 
     expect(wordSearch.find(['coffee'])).toEqual(expectedResults)
   })
-  xit('can locate that different left to right word in a different position', () => {
+  xit('should locate that different left to right word in a different position', () => {
     const grid = ['xcoffeezlp']
     const expectedResults = {
       coffee: {
@@ -68,7 +68,7 @@ describe('single line grids', () => {
 })
 
 describe('multi line grids', () => {
-  xit('can locate a left to right word in a two line grid', () => {
+  xit('should locate a left to right word in a two line grid', () => {
     const grid = ['jefblpepre', 'clojurermt']
 
     const expectedResults = {
@@ -82,7 +82,7 @@ describe('multi line grids', () => {
 
     expect(wordSearch.find(['clojure'])).toEqual(expectedResults)
   })
-  xit('can locate a left to right word in a different position in a two line grid', () => {
+  xit('should locate a left to right word in a different position in a two line grid', () => {
     const grid = ['jefblpepre', 'tclojurerm']
     const expectedResults = {
       clojure: {
@@ -94,7 +94,7 @@ describe('multi line grids', () => {
 
     expect(wordSearch.find(['clojure'])).toEqual(expectedResults)
   })
-  xit('can locate a left to right word in a three line grid', () => {
+  xit('should locate a left to right word in a three line grid', () => {
     const grid = ['camdcimgtc', 'jefblpepre', 'clojurermt']
     const expectedResults = {
       clojure: {
@@ -107,7 +107,7 @@ describe('multi line grids', () => {
     expect(wordSearch.find(['clojure'])).toEqual(expectedResults)
   })
 
-  xit('can locate a left to right word in a ten line grid', () => {
+  xit('should locate a left to right word in a ten line grid', () => {
     const grid = [
       'jefblpepre',
       'camdcimgtc',
@@ -132,7 +132,7 @@ describe('multi line grids', () => {
     expect(wordSearch.find(['clojure'])).toEqual(expectedResults)
   })
 
-  xit('can locate a left to right word in a different position in a ten line grid', () => {
+  xit('should locate a left to right word in a different position in a ten line grid', () => {
     const grid = [
       'jefblpepre',
       'camdcimgtc',
@@ -156,7 +156,7 @@ describe('multi line grids', () => {
 
     expect(wordSearch.find(['clojure'])).toEqual(expectedResults)
   })
-  xit('can locate a different left to right word in a ten line grid', () => {
+  xit('should locate a different left to right word in a ten line grid', () => {
     const grid = [
       'jefblpepre',
       'camdcimgtc',
@@ -181,8 +181,8 @@ describe('multi line grids', () => {
   })
 })
 
-describe('can find multiple words', () => {
-  xit('can find two words written left to right', () => {
+describe('multiple words', () => {
+  xit('should locate two words written left to right', () => {
     const grid = [
       'aefblpepre',
       'camdcimgtc',

--- a/exercises/practice/word-search/word-search.test.ts
+++ b/exercises/practice/word-search/word-search.test.ts
@@ -53,6 +53,7 @@ describe('single line grids', () => {
 
     expect(wordSearch.find(['coffee'])).toEqual(expectedResults)
   })
+
   xit('should locate that different left to right word in a different position', () => {
     const grid = ['xcoffeezlp']
     const expectedResults = {
@@ -82,6 +83,7 @@ describe('multi line grids', () => {
 
     expect(wordSearch.find(['clojure'])).toEqual(expectedResults)
   })
+
   xit('should locate a left to right word in a different position in a two line grid', () => {
     const grid = ['jefblpepre', 'tclojurerm']
     const expectedResults = {
@@ -94,6 +96,7 @@ describe('multi line grids', () => {
 
     expect(wordSearch.find(['clojure'])).toEqual(expectedResults)
   })
+
   xit('should locate a left to right word in a three line grid', () => {
     const grid = ['camdcimgtc', 'jefblpepre', 'clojurermt']
     const expectedResults = {
@@ -156,6 +159,7 @@ describe('multi line grids', () => {
 
     expect(wordSearch.find(['clojure'])).toEqual(expectedResults)
   })
+
   xit('should locate a different left to right word in a ten line grid', () => {
     const grid = [
       'jefblpepre',
@@ -225,6 +229,7 @@ describe('different directions', () => {
 
     expect(wordSearch.find(['elixir'])).toEqual(expectedResults)
   })
+
   xit('should locate multiple words written in different horizontal directions', () => {
     const grid = [
       'jefblpepre',
@@ -287,6 +292,7 @@ describe('vertical directions', () => {
       expectedResults
     )
   })
+
   xit('should locate words written bottom to top', () => {
     const grid = [
       'jefblpepre',
@@ -324,6 +330,7 @@ describe('vertical directions', () => {
       wordSearch.find(['elixir', 'clojure', 'ecmascript', 'rust'])
     ).toEqual(expectedResults)
   })
+
   xit('should locate words written top left to bottom right', () => {
     const grid = [
       'jefblpepre',
@@ -365,6 +372,7 @@ describe('vertical directions', () => {
       wordSearch.find(['clojure', 'elixir', 'ecmascript', 'rust', 'java'])
     ).toEqual(expectedResults)
   })
+
   xit('should locate words written bottom right to top left', () => {
     const grid = [
       'jefblpepre',
@@ -418,6 +426,7 @@ describe('vertical directions', () => {
       ])
     ).toEqual(expectedResults)
   })
+
   xit('should locate words written bottom left to top right', () => {
     const grid = [
       'jefblpepre',
@@ -476,6 +485,7 @@ describe('vertical directions', () => {
       ])
     ).toEqual(expectedResults)
   })
+
   xit('should locate words written top right to bottom left', () => {
     const grid = [
       'jefblpepre',
@@ -538,5 +548,122 @@ describe('vertical directions', () => {
         'ruby',
       ])
     ).toEqual(expectedResults)
+  })
+})
+
+describe('avoiding false-positives', () => {
+  xit('should fail to locate a word that is not in the puzzle', () => {
+    const grid = [
+      'jefblpepre',
+      'camdcimgtc',
+      'oivokprjsm',
+      'pbwasqroua',
+      'rixilelhrs',
+      'wolcqlirpc',
+      'screeaumgr',
+      'alxhpburyi',
+      'jalaycalmp',
+      'clojurermt',
+    ]
+
+    const expectedResults = {
+      clojure: {
+        start: [10, 1],
+        end: [10, 7],
+      },
+      elixir: {
+        start: [5, 6],
+        end: [5, 1],
+      },
+      ecmascript: {
+        start: [1, 10],
+        end: [10, 10],
+      },
+      rust: {
+        start: [5, 9],
+        end: [2, 9],
+      },
+      java: {
+        start: [1, 1],
+        end: [4, 4],
+      },
+      lua: {
+        start: [9, 8],
+        end: [7, 6],
+      },
+      lisp: {
+        start: [6, 3],
+        end: [3, 6],
+      },
+      ruby: {
+        start: [6, 8],
+        end: [9, 5],
+      },
+      haskell: undefined,
+    }
+    const wordSearch = new WordSearch(grid)
+
+    expect(
+      wordSearch.find([
+        'clojure',
+        'elixir',
+        'ecmascript',
+        'rust',
+        'java',
+        'lua',
+        'lisp',
+        'ruby',
+        'haskell',
+      ])
+    ).toEqual(expectedResults)
+  })
+
+  xit('should fail to locate words that are not on horizontal, vertical, or diagonal lines', () => {
+    const grid = ['abc', 'def']
+
+    const expectedResults = {
+      aef: undefined,
+      ced: undefined,
+      abf: undefined,
+      cbd: undefined,
+    }
+    const wordSearch = new WordSearch(grid)
+
+    expect(wordSearch.find(['aef', 'ced', 'abf', 'cbd'])).toEqual(
+      expectedResults
+    )
+  })
+
+  xit('should not concatenate different lines to find a horizontal word', () => {
+    const grid = ['abceli', 'xirdfg']
+
+    const expectedResults = {
+      elixir: undefined,
+    }
+    const wordSearch = new WordSearch(grid)
+
+    expect(wordSearch.find(['elixir'])).toEqual(expectedResults)
+  })
+
+  xit('should not wrap around horizontally to find a word', () => {
+    const grid = ['silabcdefp']
+
+    const expectedResults = {
+      lisp: undefined,
+    }
+    const wordSearch = new WordSearch(grid)
+
+    expect(wordSearch.find(['lisp'])).toEqual(expectedResults)
+  })
+
+  xit('should not wrap around vertically to find a word', () => {
+    const grid = ['s', 'u', 'r', 'a', 'b', 'c', 't']
+
+    const expectedResults = {
+      rust: undefined,
+    }
+    const wordSearch = new WordSearch(grid)
+
+    expect(wordSearch.find(['rust'])).toEqual(expectedResults)
   })
 })


### PR DESCRIPTION
5 new tests, but one of them as mistakenly already marked in tests.toml as implemented. Plus tiny rewording of existing tests to use matching vocabulary.