### PR TITLE
Test 6 is wrong for Resistr Color Duo exercice

### DIFF
--- a/exercises/practice/resistor-color-duo/resistor-color-duo.test.ts
+++ b/exercises/practice/resistor-color-duo/resistor-color-duo.test.ts
@@ -22,7 +22,7 @@ describe('Resistor Colors', () => {
   })
 
   xit('Ignore additional colors', () => {
-    expect(decodedValue(['green', 'brown', 'orange'])).toEqual(51)
+    expect(decodedValue(['green', 'brown', 'orange'])).toEqual(513)
   })
 
   xit('Black and brown, one-digit', () => {


### PR DESCRIPTION
This test is wrong, expected value should be 513 instead of 51 (We have 3 colors)