### PR TITLE
Sync isbn-verifier

### DIFF
--- a/exercises/practice/isbn-verifier/.docs/instructions.md
+++ b/exercises/practice/isbn-verifier/.docs/instructions.md
@@ -1,23 +1,26 @@
 # Instructions
 
-The [ISBN-10 verification process](https://en.wikipedia.org/wiki/International_Standard_Book_Number) is used to validate book identification
-numbers. These normally contain dashes and look like: `3-598-21508-8`
+The [ISBN-10 verification process][isbn-verification] is used to validate book identification numbers.
+These normally contain dashes and look like: `3-598-21508-8`
 
 ## ISBN
 
-The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
+The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only).
+In the case the check character is an X, this represents the value '10'.
+These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
 
-```
-(x1 * 10 + x2 * 9 + x3 * 8 + x4 * 7 + x5 * 6 + x6 * 5 + x7 * 4 + x8 * 3 + x9 * 2 + x10 * 1) mod 11 == 0
+```text
+(d₁ * 10 + d₂ * 9 + d₃ * 8 + d₄ * 7 + d₅ * 6 + d₆ * 5 + d₇ * 4 + d₈ * 3 + d₉ * 2 + d₁₀ * 1) mod 11 == 0
 ```
 
 If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
 
 ## Example
 
-Let's take the ISBN-10 `3-598-21508-8`. We plug it in to the formula, and get:
+Let's take the ISBN-10 `3-598-21508-8`.
+We plug it in to the formula, and get:
 
-```
+```text
 (3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
 ```
 
@@ -33,10 +36,7 @@ The program should be able to verify ISBN-10 both with and without separating da
 ## Caveats
 
 Converting from strings to numbers can be tricky in certain languages.
-Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10'). For instance `3-598-21507-X` is a valid ISBN-10.
+Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10').
+For instance `3-598-21507-X` is a valid ISBN-10.
 
-## Bonus tasks
-
-- Generate a valid ISBN-13 from the input ISBN-10 (and maybe verify it again with a derived verifier).
-
-- Generate valid ISBN, maybe even from a given starting ISBN.
+[isbn-verification]: https://en.wikipedia.org/wiki/International_Standard_Book_Number

--- a/exercises/practice/isbn-verifier/.meta/tests.toml
+++ b/exercises/practice/isbn-verifier/.meta/tests.toml
@@ -1,21 +1,31 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [0caa3eac-d2e3-4c29-8df8-b188bc8c9292]
-description = "valid isbn number"
+description = "valid isbn"
 
 [19f76b53-7c24-45f8-87b8-4604d0ccd248]
 description = "invalid isbn check digit"
 
 [4164bfee-fb0a-4a1c-9f70-64c6a1903dcd]
-description = "valid isbn number with a check digit of 10"
+description = "valid isbn with a check digit of 10"
 
 [3ed50db1-8982-4423-a993-93174a20825c]
 description = "check digit is a character other than X"
 
+[9416f4a5-fe01-4b61-a07b-eb75892ef562]
+description = "invalid check digit in isbn is not treated as zero"
+
 [c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec]
-description = "invalid character in isbn"
+description = "invalid character in isbn is not treated as zero"
 
 [28025280-2c39-4092-9719-f3234b89c627]
 description = "X is only valid as a check digit"
@@ -48,7 +58,10 @@ description = "empty isbn"
 description = "input is 9 characters"
 
 [ed6e8d1b-382c-4081-8326-8b772c581fec]
-description = "invalid characters are not ignored"
+description = "invalid characters are not ignored after checking length"
+
+[daad3e58-ce00-4395-8a8e-e3eded1cdc86]
+description = "invalid characters are not ignored before checking length"
 
 [fb5e48d8-7c03-4bfb-a088-b101df16fdc3]
 description = "input is too long but contains a valid isbn"

--- a/exercises/practice/isbn-verifier/isbn-verifier.test.ts
+++ b/exercises/practice/isbn-verifier/isbn-verifier.test.ts
@@ -1,7 +1,7 @@
 import { isValid } from './isbn-verifier'
 
 describe('ISBN Verifier', () => {
-  it('valid isbn number', () => {
+  it('valid isbn', () => {
     expect(isValid('3-598-21508-8')).toBeTruthy()
   })
 
@@ -9,7 +9,7 @@ describe('ISBN Verifier', () => {
     expect(isValid('3-598-21508-9')).toBeFalsy()
   })
 
-  xit('valid isbn number with a check digit of 10', () => {
+  xit('valid isbn with a check digit of 10', () => {
     expect(isValid('3-598-21507-X')).toBeTruthy()
   })
 
@@ -17,7 +17,11 @@ describe('ISBN Verifier', () => {
     expect(isValid('3-598-21507-A')).toBeFalsy()
   })
 
-  xit('invalid character in isbn', () => {
+  xit('invalid check digit in isbn is not treated as zero', () => {
+    expect(isValid('4-598-21507-B')).toBeFalsy()
+  })
+
+  xit('invalid character in isbn is not treated as zero', () => {
     expect(isValid('3-598-2K507-0')).toBeFalsy()
   })
 
@@ -37,16 +41,20 @@ describe('ISBN Verifier', () => {
     expect(isValid('359821507')).toBeFalsy()
   })
 
+  xit('too long isbn', () => {
+    expect(isValid('3-598-21507-XX')).toBeFalsy()
+  })
+
   xit('too long isbn and no dashes', () => {
     expect(isValid('3598215078X')).toBeFalsy()
   })
 
-  xit('isbn without check digit', () => {
-    expect(isValid('3-598-21507')).toBeFalsy()
+  xit('too short isbn', () => {
+    expect(isValid('00')).toBeFalsy()
   })
 
-  xit('too long isbn', () => {
-    expect(isValid('3-598-21507-XX')).toBeFalsy()
+  xit('isbn without check digit', () => {
+    expect(isValid('3-598-21507')).toBeFalsy()
   })
 
   xit('check digit of X should not be used for 0', () => {
@@ -55,5 +63,21 @@ describe('ISBN Verifier', () => {
 
   xit('empty isbn', () => {
     expect(isValid('')).toBeFalsy()
+  })
+
+  xit('input is 9 characters', () => {
+    expect(isValid('134456729')).toBeFalsy()
+  })
+
+  xit('invalid characters are not ignored after checking length', () => {
+    expect(isValid('3132P34035')).toBeFalsy()
+  })
+
+  xit('invalid characters are not ignored before checking length', () => {
+    expect(isValid('3598P215088')).toBeFalsy()
+  })
+
+  xit('input is too long but contains a valid isbn', () => {
+    expect(isValid('98245726788')).toBeFalsy()
   })
 })


### PR DESCRIPTION
6 new tests (more than tests.toml reports because some were missing), one test ('isbn too long') reordered, 3 more tests renamed.