### PR TITLE
Sync gigasecond

### DIFF
--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -20,5 +20,5 @@
   },
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"
+  "source_url": "https://pine.fm/LearnToProgram/?Chapter=09"
 }

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [92fbe71c-ea52-4fac-bd77-be38023cacf7]
 description = "date only specification of time"
@@ -16,3 +23,6 @@ description = "full time specified"
 
 [09d4e30e-728a-4b52-9005-be44a58d9eba]
 description = "full time with day roll-over"
+
+[fcec307c-7529-49ab-b0fe-20309197618a]
+description = "does not mutate the input"

--- a/exercises/practice/gigasecond/gigasecond.test.ts
+++ b/exercises/practice/gigasecond/gigasecond.test.ts
@@ -1,27 +1,39 @@
 import { Gigasecond } from './gigasecond'
 
 describe('Gigasecond', () => {
-  it('tells a gigasecond anniversary since midnight', () => {
-    const gs = new Gigasecond(new Date(Date.UTC(2015, 8, 14)))
-    const expectedDate = new Date(Date.UTC(2047, 4, 23, 1, 46, 40))
+  it('date only specification of time', () => {
+    const gs = new Gigasecond(new Date(Date.parse('2011-04-25')))
+    const expectedDate = new Date(Date.parse('2043-01-01T01:46:40Z'))
     expect(gs.date()).toEqual(expectedDate)
   })
 
-  xit('tells the anniversary is next day when you are born at night', () => {
-    const gs = new Gigasecond(new Date(Date.UTC(2015, 8, 14, 23, 59, 59)))
-    const expectedDate = new Date(Date.UTC(2047, 4, 24, 1, 46, 39))
+  xit('second test for date only specification of time', () => {
+    const gs = new Gigasecond(new Date(Date.parse('1977-06-13')))
+    const expectedDate = new Date(Date.parse('2009-02-19T01:46:40Z'))
     expect(gs.date()).toEqual(expectedDate)
   })
 
-  xit('even works before 1970 (beginning of Unix epoch )', () => {
-    const gs = new Gigasecond(new Date(Date.UTC(1959, 6, 19, 5, 13, 45)))
-    const expectedDate = new Date(Date.UTC(1991, 2, 27, 7, 0, 25))
+  xit('third test for date only specification of time', () => {
+    const gs = new Gigasecond(new Date(Date.parse('1959-07-19')))
+    const expectedDate = new Date(Date.parse('1991-03-27T01:46:40Z'))
     expect(gs.date()).toEqual(expectedDate)
   })
 
-  xit('make sure calling "date" doesn\'t mutate value', () => {
-    const gs = new Gigasecond(new Date(Date.UTC(1959, 6, 19, 5, 13, 45)))
-    const expectedDate = new Date(Date.UTC(1991, 2, 27, 7, 0, 25))
+  xit('full time specified', () => {
+    const gs = new Gigasecond(new Date(Date.parse('2015-01-24T22:00:00Z')))
+    const expectedDate = new Date(Date.parse('2046-10-02T23:46:40Z'))
+    expect(gs.date()).toEqual(expectedDate)
+  })
+
+  xit('full time with day roll-over', () => {
+    const gs = new Gigasecond(new Date(Date.parse('2015-01-24T23:59:59Z')))
+    const expectedDate = new Date(Date.parse('2046-10-03T01:46:39Z'))
+    expect(gs.date()).toEqual(expectedDate)
+  })
+
+  xit('does not mutate the input', () => {
+    const gs = new Gigasecond(new Date(Date.parse('2015-01-24T23:59:59Z')))
+    const expectedDate = new Date(Date.parse('2046-10-03T01:46:39Z'))
     gs.date()
     expect(gs.date()).toEqual(expectedDate)
   })


### PR DESCRIPTION
2 tests were missing, but the existing tests had different inputs than in problem specifications. So I rewrote all the tests. I used `Date.parse` everywhere to get around the mindfuck of 0-indexed months. Let me know if that was not desirable.