### PR TITLE
Sync armstrong-numbers

### DIFF
--- a/exercises/practice/armstrong-numbers/.docs/instructions.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-An [Armstrong number](https://en.wikipedia.org/wiki/Narcissistic_number) is a number that is the sum of its own digits each raised to the power of the number of digits.
+An [Armstrong number][armstrong-number] is a number that is the sum of its own digits each raised to the power of the number of digits.
 
 For example:
 
@@ -10,3 +10,5 @@ For example:
 - 154 is _not_ an Armstrong number, because: `154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190`
 
 Write some code to determine whether a number is an Armstrong number.
+
+[armstrong-number]: https://en.wikipedia.org/wiki/Narcissistic_number

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -17,7 +17,7 @@
       ".meta/proof.ci.ts"
     ]
   },
-  "blurb": "Determine if a number is an Armstrong number",
+  "blurb": "Determine if a number is an Armstrong number.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"
 }

--- a/exercises/practice/armstrong-numbers/.meta/proof.ci.ts
+++ b/exercises/practice/armstrong-numbers/.meta/proof.ci.ts
@@ -4,5 +4,6 @@ export function isArmstrongNumber(input: number | bigint): boolean {
     return total + BigInt(parseInt(current, 10)) ** BigInt(digits.length)
   }, BigInt(0))
 
+  // eslint-disable-next-line eqeqeq
   return sum == input
 }

--- a/exercises/practice/armstrong-numbers/.meta/proof.ci.ts
+++ b/exercises/practice/armstrong-numbers/.meta/proof.ci.ts
@@ -1,7 +1,8 @@
-export function isArmstrongNumber(input: number): boolean {
+export function isArmstrongNumber(input: number | bigint): boolean {
   const digits = String(input).split('')
   const sum = digits.reduce((total, current) => {
-    return total + Math.pow(parseInt(current, 10), digits.length)
-  }, 0)
-  return sum === input
+    return total + BigInt(parseInt(current, 10)) ** BigInt(digits.length)
+  }, BigInt(0))
+
+  return sum == input
 }

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,30 +1,43 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [c1ed103c-258d-45b2-be73-d8c6d9580c7b]
 description = "Zero is an Armstrong number"
 
 [579e8f03-9659-4b85-a1a2-d64350f6b17a]
-description = "Single digit numbers are Armstrong numbers"
+description = "Single-digit numbers are Armstrong numbers"
 
 [2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
-description = "There are no 2 digit Armstrong numbers"
+description = "There are no two-digit Armstrong numbers"
 
 [509c087f-e327-4113-a7d2-26a4e9d18283]
-description = "Three digit number that is an Armstrong number"
+description = "Three-digit number that is an Armstrong number"
 
 [7154547d-c2ce-468d-b214-4cb953b870cf]
-description = "Three digit number that is not an Armstrong number"
+description = "Three-digit number that is not an Armstrong number"
 
 [6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
-description = "Four digit number that is an Armstrong number"
+description = "Four-digit number that is an Armstrong number"
 
 [eed4b331-af80-45b5-a80b-19c9ea444b2e]
-description = "Four digit number that is not an Armstrong number"
+description = "Four-digit number that is not an Armstrong number"
 
 [f971ced7-8d68-4758-aea1-d4194900b864]
-description = "Seven digit number that is an Armstrong number"
+description = "Seven-digit number that is an Armstrong number"
 
 [7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
-description = "Seven digit number that is not an Armstrong number"
+description = "Seven-digit number that is not an Armstrong number"
+
+[5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
+description = "Armstrong number containing seven zeroes"
+
+[12ffbf10-307a-434e-b4ad-c925680e1dd4]
+description = "The largest and last Armstrong number"

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.test.ts
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.test.ts
@@ -32,4 +32,16 @@ describe('Armstrong Numbers', () => {
   xit('Seven digit number that is not an Armstrong number', () => {
     expect(isArmstrongNumber(9926314)).toBeFalsy()
   })
+
+  xit('Armstrong number containing seven zeroes', () => {
+    expect(
+      isArmstrongNumber(BigInt('186709961001538790100634132976990'))
+    ).toBeTruthy()
+  })
+
+  xit('The largest and last Armstrong number', () => {
+    expect(
+      isArmstrongNumber(BigInt('115132219018763992565095597973971522401'))
+    ).toBeTruthy()
+  })
 })

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.test.ts
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.test.ts
@@ -1,35 +1,35 @@
 import { isArmstrongNumber } from './armstrong-numbers'
 
 describe('Armstrong Numbers', () => {
-  it('Single digit numbers are Armstrong numbers', () => {
+  it('Single-digit numbers are Armstrong numbers', () => {
     expect(isArmstrongNumber(5)).toBeTruthy()
   })
 
-  xit('There are no 2 digit Armstrong numbers', () => {
+  xit('There are no two-digit Armstrong numbers', () => {
     expect(isArmstrongNumber(10)).toBeFalsy()
   })
 
-  xit('Three digit number that is an Armstrong number', () => {
+  xit('Three-digit number that is an Armstrong number', () => {
     expect(isArmstrongNumber(153)).toBeTruthy()
   })
 
-  xit('Three digit number that is not an Armstrong number', () => {
+  xit('Three-digit number that is not an Armstrong number', () => {
     expect(isArmstrongNumber(100)).toBeFalsy()
   })
 
-  xit('Four digit number that is an Armstrong number', () => {
+  xit('Four-digit number that is an Armstrong number', () => {
     expect(isArmstrongNumber(9474)).toBeTruthy()
   })
 
-  xit('Four digit number that is not an Armstrong number', () => {
+  xit('Four-digit number that is not an Armstrong number', () => {
     expect(isArmstrongNumber(9475)).toBeFalsy()
   })
 
-  xit('Seven digit number that is an Armstrong number', () => {
+  xit('Seven-digit number that is an Armstrong number', () => {
     expect(isArmstrongNumber(9926315)).toBeTruthy()
   })
 
-  xit('Seven digit number that is not an Armstrong number', () => {
+  xit('Seven-digit number that is not an Armstrong number', () => {
     expect(isArmstrongNumber(9926314)).toBeFalsy()
   })
 


### PR DESCRIPTION
This exercise receives 2 new tests that both deal with numbers so big that the `Number` type can't handle. We can either ignore those two tests and keep the exercise as it is, or add the new tests and extend the exercise so that it's necessary to use `BigInt` (this PR does that). Let me know which one you prefer. The JavaScript track doesn't have armstrong-numbers up to date.

