### PR TITLE
Sync list-ops & deprecate accumulate

### DIFF
--- a/config.json
+++ b/config.json
@@ -1058,7 +1058,8 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "callbacks", "conditionals", "lists"]
+        "topics": ["algorithms", "callbacks", "conditionals", "lists"],
+        "status": "deprecated"
       },
       {
         "slug": "all-your-base",

--- a/exercises/practice/list-ops/.docs/instructions.md
+++ b/exercises/practice/list-ops/.docs/instructions.md
@@ -2,13 +2,10 @@
 
 Implement basic list operations.
 
-In functional languages list operations like `length`, `map`, and
-`reduce` are very common. Implement a series of basic list operations,
-without using existing functions.
+In functional languages list operations like `length`, `map`, and `reduce` are very common.
+Implement a series of basic list operations, without using existing functions.
 
-The precise number and names of the operations to be implemented will be
-track dependent to avoid conflicts with existing names, but the general
-operations you will implement include:
+The precise number and names of the operations to be implemented will be track dependent to avoid conflicts with existing names, but the general operations you will implement include:
 
 - `append` (_given two lists, add all items in the second list to the end of the first list_);
 - `concatenate` (_given a series of lists, combine all items in all lists into one flattened list_);

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -19,5 +19,5 @@
       ".meta/proof.ci.ts"
     ]
   },
-  "blurb": "Implement basic list operations"
+  "blurb": "Implement basic list operations."
 }

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -1,66 +1,106 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [485b9452-bf94-40f7-a3db-c3cf4850066a]
-description = "empty lists"
+description = "append entries to a list and return the new list -> empty lists"
 
 [2c894696-b609-4569-b149-8672134d340a]
-description = "list to empty list"
+description = "append entries to a list and return the new list -> list to empty list"
+
+[e842efed-3bf6-4295-b371-4d67a4fdf19c]
+description = "append entries to a list and return the new list -> empty list to list"
 
 [71dcf5eb-73ae-4a0e-b744-a52ee387922f]
-description = "non-empty lists"
+description = "append entries to a list and return the new list -> non-empty lists"
 
 [28444355-201b-4af2-a2f6-5550227bde21]
-description = "empty list"
+description = "concatenate a list of lists -> empty list"
 
 [331451c1-9573-42a1-9869-2d06e3b389a9]
-description = "list of lists"
+description = "concatenate a list of lists -> list of lists"
 
 [d6ecd72c-197f-40c3-89a4-aa1f45827e09]
-description = "list of nested lists"
+description = "concatenate a list of lists -> list of nested lists"
 
 [0524fba8-3e0f-4531-ad2b-f7a43da86a16]
-description = "empty list"
+description = "filter list returning only values that satisfy the filter function -> empty list"
 
 [88494bd5-f520-4edb-8631-88e415b62d24]
-description = "non-empty list"
+description = "filter list returning only values that satisfy the filter function -> non-empty list"
 
 [1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad]
-description = "empty list"
+description = "returns the length of a list -> empty list"
 
 [d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e]
-description = "non-empty list"
+description = "returns the length of a list -> non-empty list"
 
 [c0bc8962-30e2-4bec-9ae4-668b8ecd75aa]
-description = "empty list"
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> empty list"
 
 [11e71a95-e78b-4909-b8e4-60cdcaec0e91]
-description = "non-empty list"
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> non-empty list"
 
 [613b20b7-1873-4070-a3a6-70ae5f50d7cc]
-description = "empty list"
+description = "folds (reduces) the given list from the left with a function -> empty list"
+include = false
 
 [e56df3eb-9405-416a-b13a-aabb4c3b5194]
-description = "direction independent function applied to non-empty list"
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+include = false
 
 [d2cf5644-aee1-4dfc-9b88-06896676fe27]
-description = "direction dependent function applied to non-empty list"
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+include = false
+
+[36549237-f765-4a4c-bfd9-5d3a8f7b07d2]
+description = "folds (reduces) the given list from the left with a function -> empty list"
+reimplements = "613b20b7-1873-4070-a3a6-70ae5f50d7cc"
+
+[7a626a3c-03ec-42bc-9840-53f280e13067]
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+reimplements = "e56df3eb-9405-416a-b13a-aabb4c3b5194"
+
+[d7fcad99-e88e-40e1-a539-4c519681f390]
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+reimplements = "d2cf5644-aee1-4dfc-9b88-06896676fe27"
 
 [aeb576b9-118e-4a57-a451-db49fac20fdc]
-description = "empty list"
+description = "folds (reduces) the given list from the right with a function -> empty list"
+include = false
 
 [c4b64e58-313e-4c47-9c68-7764964efb8e]
-description = "direction independent function applied to non-empty list"
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+include = false
 
 [be396a53-c074-4db3-8dd6-f7ed003cce7c]
-description = "direction dependent function applied to non-empty list"
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+include = false
+
+[17214edb-20ba-42fc-bda8-000a5ab525b0]
+description = "folds (reduces) the given list from the right with a function -> empty list"
+reimplements = "aeb576b9-118e-4a57-a451-db49fac20fdc"
+
+[e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd]
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+reimplements = "c4b64e58-313e-4c47-9c68-7764964efb8e"
+
+[8066003b-f2ff-437e-9103-66e6df474844]
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+reimplements = "be396a53-c074-4db3-8dd6-f7ed003cce7c"
 
 [94231515-050e-4841-943d-d4488ab4ee30]
-description = "empty list"
+description = "reverse the elements of the list -> empty list"
 
 [fcc03d1e-42e0-4712-b689-d54ad761f360]
-description = "non-empty list"
+description = "reverse the elements of the list -> non-empty list"
 
 [40872990-b5b8-4cb8-9085-d91fc0d05d26]
-description = "list of lists is not flattened"
+description = "reverse the elements of the list -> list of lists is not flattened"

--- a/exercises/practice/list-ops/list-ops.test.ts
+++ b/exercises/practice/list-ops/list-ops.test.ts
@@ -46,6 +46,12 @@ describe('append entries to a list and return the new list', () => {
     expect(list1.append(list2)).toEqual(List.create())
   })
 
+  xit('list to empty list', () => {
+    const list1 = List.create()
+    const list2 = List.create(1, 2, 3, 4)
+    expect(list1.append(list2)).toEqual(list2)
+  })
+
   xit('empty list to list', () => {
     const list1 = List.create(1, 2, 3, 4)
     const list2 = List.create()


### PR DESCRIPTION
Accumulate is deprecated in problem-specs in favor of list-ops.

List-ops receive one new test - the other "reimplements" tests were already implemented in the newer form (using variable names `acc` and `el` instead of `x` and `y`).