### PR TITLE
Add exercise darts

### DIFF
--- a/config.json
+++ b/config.json
@@ -109,6 +109,14 @@
         "topics": ["classes"]
       },
       {
+        "slug": "darts",
+        "name": "Darts",
+        "uuid": "5697c090-4ab3-4f76-b9d2-a82330a27a91",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
         "slug": "pangram",
         "name": "Pangram",
         "uuid": "721d9c74-cc16-4b32-8f0b-ffab75027539",

--- a/exercises/practice/darts/.docs/instructions.md
+++ b/exercises/practice/darts/.docs/instructions.md
@@ -1,0 +1,23 @@
+# Instructions
+
+Write a function that returns the earned points in a single toss of a Darts game.
+
+[Darts][darts] is a game where players throw darts at a [target][darts-target].
+
+In our particular instance of the game, the target rewards 4 different amounts of points, depending on where the dart lands:
+
+- If the dart lands outside the target, player earns no points (0 points).
+- If the dart lands in the outer circle of the target, player earns 1 point.
+- If the dart lands in the middle circle of the target, player earns 5 points.
+- If the dart lands in the inner circle of the target, player earns 10 points.
+
+The outer circle has a radius of 10 units (this is equivalent to the total radius for the entire target), the middle circle a radius of 5 units, and the inner circle a radius of 1.
+Of course, they are all centered at the same point — that is, the circles are [concentric][] defined by the coordinates (0, 0).
+
+Write a function that given a point in the target (defined by its [Cartesian coordinates][cartesian-coordinates] `x` and `y`, where `x` and `y` are [real][real-numbers]), returns the correct amount earned by a dart landing at that point.
+
+[darts]: https://en.wikipedia.org/wiki/Darts
+[darts-target]: https://en.wikipedia.org/wiki/Darts#/media/File:Darts_in_a_dartboard.jpg
+[concentric]: https://mathworld.wolfram.com/ConcentricCircles.html
+[cartesian-coordinates]: https://www.mathsisfun.com/data/cartesian-coordinates.html
+[real-numbers]: https://www.mathsisfun.com/numbers/real-numbers.html

--- a/exercises/practice/darts/.eslintignore
+++ b/exercises/practice/darts/.eslintignore
@@ -1,0 +1,13 @@
+!.meta
+
+# Protected or generated
+.git
+.vscode
+
+# When using npm
+node_modules/*
+
+# Configuration files
+.eslintrc.cjs
+babel.config.cjs
+jest.config.cjs

--- a/exercises/practice/darts/.eslintrc.cjs
+++ b/exercises/practice/darts/.eslintrc.cjs
@@ -1,0 +1,38 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.json'],
+  },
+  overrides: [
+    // Student provided files
+    {
+      files: ['*.ts'],
+      excludedFiles: ['.meta/proof.ci.ts', '.meta/exemplar.ts', '*.test.ts'],
+      extends: '@exercism/eslint-config-typescript',
+    },
+    // Exercism given tests
+    {
+      files: ['*.test.ts'],
+      excludedFiles: ['custom.test.ts'],
+      env: {
+        jest: true,
+      },
+      extends: '@exercism/eslint-config-typescript/maintainers',
+    },
+    // Student provided tests
+    {
+      files: ['custom.test.ts'],
+      env: {
+        jest: true,
+      },
+      extends: '@exercism/eslint-config-typescript',
+    },
+    // Exercism provided files
+    {
+      files: ['.meta/proof.ci.ts', '.meta/exemplar.ts', '*.test.ts'],
+      excludedFiles: ['custom.test.ts'],
+      extends: '@exercism/eslint-config-typescript/maintainers',
+    },
+  ],
+}

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -2,7 +2,9 @@
   "authors": [
     "angelikatyborska"
   ],
-  "contributors": [],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
     "solution": [
       "darts.ts"

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "angelikatyborska"
+  ],
+  "contributors": [],
+  "files": {
+    "solution": [
+      "darts.ts"
+    ],
+    "test": [
+      "darts.test.ts"
+    ],
+    "example": [
+      ".meta/proof.ci.ts"
+    ]
+  },
+  "blurb": "Write a function that returns the earned points in a single toss of a Darts game.",
+  "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
+}

--- a/exercises/practice/darts/.meta/proof.ci.ts
+++ b/exercises/practice/darts/.meta/proof.ci.ts
@@ -3,15 +3,15 @@ export function score(x: number, y: number): number {
   const distanceToDart = Math.sqrt(x * x + y * y)
 
   // Define points for each section of the target
-  if (distanceToDart > 10) { 
+  if (distanceToDart > 10) {
     return 0
   }
-  
+
   if (distanceToDart > 5) {
     return 1
   }
-  
-  if (distanceToDart > 1) { 
+
+  if (distanceToDart > 1) {
     return 5
   }
   return 10

--- a/exercises/practice/darts/.meta/proof.ci.ts
+++ b/exercises/practice/darts/.meta/proof.ci.ts
@@ -3,8 +3,16 @@ export function score(x: number, y: number): number {
   const distanceToDart = Math.sqrt(x * x + y * y)
 
   // Define points for each section of the target
-  if (distanceToDart > 10) return 0
-  if (distanceToDart > 5) return 1
-  if (distanceToDart > 1) return 5
+  if (distanceToDart > 10) { 
+    return 0
+  }
+  
+  if (distanceToDart > 5) {
+    return 1
+  }
+  
+  if (distanceToDart > 1) { 
+    return 5
+  }
   return 10
 }

--- a/exercises/practice/darts/.meta/proof.ci.ts
+++ b/exercises/practice/darts/.meta/proof.ci.ts
@@ -1,0 +1,10 @@
+export function score(x: number, y: number): number {
+  // Use euclidean distance
+  const distanceToDart = Math.sqrt(x * x + y * y)
+
+  // Define points for each section of the target
+  if (distanceToDart > 10) return 0
+  if (distanceToDart > 5) return 1
+  if (distanceToDart > 1) return 5
+  return 10
+}

--- a/exercises/practice/darts/.meta/tests.toml
+++ b/exercises/practice/darts/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[9033f731-0a3a-4d9c-b1c0-34a1c8362afb]
+description = "Missed target"
+
+[4c9f6ff4-c489-45fd-be8a-1fcb08b4d0ba]
+description = "On the outer circle"
+
+[14378687-ee58-4c9b-a323-b089d5274be8]
+description = "On the middle circle"
+
+[849e2e63-85bd-4fed-bc3b-781ae962e2c9]
+description = "On the inner circle"
+
+[1c5ffd9f-ea66-462f-9f06-a1303de5a226]
+description = "Exactly on center"
+
+[b65abce3-a679-4550-8115-4b74bda06088]
+description = "Near the center"
+
+[66c29c1d-44f5-40cf-9927-e09a1305b399]
+description = "Just within the inner circle"
+
+[d1012f63-c97c-4394-b944-7beb3d0b141a]
+description = "Just outside the inner circle"
+
+[ab2b5666-b0b4-49c3-9b27-205e790ed945]
+description = "Just within the middle circle"
+
+[70f1424e-d690-4860-8caf-9740a52c0161]
+description = "Just outside the middle circle"
+
+[a7dbf8db-419c-4712-8a7f-67602b69b293]
+description = "Just within the outer circle"
+
+[e0f39315-9f9a-4546-96e4-a9475b885aa7]
+description = "Just outside the outer circle"
+
+[045d7d18-d863-4229-818e-b50828c75d19]
+description = "Asymmetric position between the inner and middle circles"

--- a/exercises/practice/darts/babel.config.cjs
+++ b/exercises/practice/darts/babel.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['@exercism/babel-preset-typescript'],
+  plugins: [],
+}

--- a/exercises/practice/darts/darts.test.ts
+++ b/exercises/practice/darts/darts.test.ts
@@ -1,0 +1,55 @@
+import { score } from './darts'
+
+describe('Darts', () => {
+  it('Missed target', () => {
+    expect(score(-9, 9)).toEqual(0)
+  })
+
+  xit('On the outer circle', () => {
+    expect(score(0, 10)).toEqual(1)
+  })
+
+  xit('On the middle circle', () => {
+    expect(score(-5, 0)).toEqual(5)
+  })
+
+  xit('On the inner circle', () => {
+    expect(score(0, -1)).toEqual(10)
+  })
+
+  xit('Exactly on centre', () => {
+    expect(score(0, 0)).toEqual(10)
+  })
+
+  xit('Near the centre', () => {
+    expect(score(-0.1, -0.1)).toEqual(10)
+  })
+
+  xit('Just within the inner circle', () => {
+    expect(score(0.7, 0.7)).toEqual(10)
+  })
+
+  xit('Just outside the inner circle', () => {
+    expect(score(0.8, -0.8)).toEqual(5)
+  })
+
+  xit('Just within the middle circle', () => {
+    expect(score(-3.5, 3.5)).toEqual(5)
+  })
+
+  xit('Just outside the middle circle', () => {
+    expect(score(-3.6, -3.6)).toEqual(1)
+  })
+
+  xit('Just within the outer circle', () => {
+    expect(score(-7.0, 7.0)).toEqual(1)
+  })
+
+  xit('Just outside the outer circle', () => {
+    expect(score(7.1, -7.1)).toEqual(0)
+  })
+
+  xit('Asymmetric position between the inner and middle circles', () => {
+    expect(score(0.5, -4)).toEqual(5)
+  })
+})

--- a/exercises/practice/darts/darts.ts
+++ b/exercises/practice/darts/darts.ts
@@ -1,0 +1,3 @@
+export function score(x: unknown, y: unknown): unknown {
+  throw new Error('Remove this statement and implement this function')
+}

--- a/exercises/practice/darts/jest.config.cjs
+++ b/exercises/practice/darts/jest.config.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  verbose: true,
+  projects: ['<rootDir>'],
+  testMatch: [
+    '**/__tests__/**/*.[jt]s?(x)',
+    '**/test/**/*.[jt]s?(x)',
+    '**/?(*.)+(spec|test).[jt]s?(x)',
+  ],
+  testPathIgnorePatterns: [
+    '/(?:production_)?node_modules/',
+    '.d.ts$',
+    '<rootDir>/test/fixtures',
+    '<rootDir>/test/helpers',
+    '__mocks__',
+  ],
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest',
+  },
+}

--- a/exercises/practice/darts/package.json
+++ b/exercises/practice/darts/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@exercism/typescript-darts",
+  "version": "1.0.0",
+  "description": "Exercism exercises in Typescript.",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/exercism/typescript"
+  },
+  "type": "module",
+  "engines": {
+    "node": "^14.13.1 || >=16.0.0"
+  },
+  "devDependencies": {
+    "@exercism/babel-preset-typescript": "^0.1.0",
+    "@exercism/eslint-config-typescript": "^0.4.1",
+    "@types/jest": "^27.4.0",
+    "@types/node": "^16.11.24",
+    "babel-jest": "^27.5.1",
+    "core-js": "^3.21.0",
+    "eslint": "^8.9.0",
+    "jest": "^27.5.1",
+    "typescript": "^4.5.4"
+  },
+  "scripts": {
+    "test": "yarn lint:types && jest --no-cache",
+    "lint": "yarn lint:types && yarn lint:ci",
+    "lint:types": "yarn tsc --noEmit -p .",
+    "lint:ci": "eslint . --ext .tsx,.ts"
+  }
+}

--- a/exercises/practice/darts/tsconfig.json
+++ b/exercises/practice/darts/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "display": "Configuration for Exercism TypeScript Exercises",
+  "compilerOptions": {
+    // Allows you to use the newest syntax, and have access to console.log
+    // https://www.typescriptlang.org/tsconfig#lib
+    "lib": ["ESNEXT", "dom"],
+    // Make sure typescript is configured to output ESM
+    // https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#how-can-i-make-my-typescript-project-output-esm
+    "module": "ES2020",
+    // Since this project is using babel, TypeScript may target something very
+    // high, and babel will make sure it runs on your local Node version.
+    // https://babeljs.io/docs/en/
+    "target": "ESNext", // ESLint doesn't support this yet: "es2022",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+
+    // Because we'll be using babel: ensure that Babel can safely transpile
+    // files in the TypeScript project.
+    //
+    // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
+    "isolatedModules": true
+  },
+  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
I copy-pasted all the boilerplate from another exercise (leap), and the proof and tests from the JavaScript. Then I slapped my name on it in the config 😛 

I wasn't sure if there is any logic to the order of exercises in the config, so I just put it somewhere in the beginning around exercises that are similarly easy.