### PR TITLE
Fix test error in resistor-color-trio exercice

### DIFF
--- a/exercises/practice/resistor-color-trio/resistor-color-trio.test.ts
+++ b/exercises/practice/resistor-color-trio/resistor-color-trio.test.ts
@@ -12,7 +12,7 @@ describe('Resistor Colors', () => {
   })
 
   xit('Red and black and red', () => {
-    expect(decodedResistorValue(['red', 'black', 'red'])).toEqual('2 kiloohms')
+    expect(decodedResistorValue(['red', 'black', 'red'])).toEqual('200 ohms')
   })
 
   xit('Green and brown and orange', () => {


### PR DESCRIPTION
Red color return hecto instead of kilo metric in test 3