### PR TITLE
Moves Resistor Color before Duo and Trio variants

### DIFF
--- a/config.json
+++ b/config.json
@@ -46,6 +46,15 @@
         "topics": ["optional_values", "strings", "text_formatting"]
       },
       {
+        "slug": "resistor-color",
+        "name": "Resistor Color",
+        "uuid": "c6f41fd5-584c-46ca-b3c5-6a0825446bf4",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "topics": ["arrays", "strings"]
+      },
+      {
         "slug": "resistor-color-duo",
         "name": "Resistor Color Duo",
         "uuid": "fd677d24-72eb-46d9-bfa4-8013e96fa71f",
@@ -71,15 +80,6 @@
         "prerequisites": [],
         "difficulty": 1,
         "topics": ["booleans", "integers", "logic"]
-      },
-      {
-        "slug": "resistor-color",
-        "name": "Resistor Color",
-        "uuid": "c6f41fd5-584c-46ca-b3c5-6a0825446bf4",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": ["arrays", "strings"]
       },
       {
         "slug": "rna-transcription",


### PR DESCRIPTION
### Context

I am really enjoying the TypeScript track as part of #12in23 and was
surprised when I hit the Resistor Color exercise having covered the more
advanced Duo and Trio exercises earlier in the track.

### Change

Moves the Resistor Color exercise before Duo and Trio variants, as it
has a lower difficulty level.

This matches other tracks such as:

- https://github.com/exercism/javascript/blob/e8fbe7b/config.json#L293-L302
- https://github.com/exercism/tcl/blob/92fb8ae/config.json#L66-L298
- https://github.com/exercism/jq/blob/5910d26/config.json#L326-L338

### Considerations

Should these three exercises be merged into one, since they build on
each other?
