### PR TITLE
Moved resistor-color exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -46,6 +46,15 @@
         "topics": ["optional_values", "strings", "text_formatting"]
       },
       {
+        "slug": "resistor-color",
+        "name": "Resistor Color",
+        "uuid": "c6f41fd5-584c-46ca-b3c5-6a0825446bf4",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "topics": ["arrays", "strings"]
+      },
+      {
         "slug": "resistor-color-duo",
         "name": "Resistor Color Duo",
         "uuid": "fd677d24-72eb-46d9-bfa4-8013e96fa71f",
@@ -71,15 +80,6 @@
         "prerequisites": [],
         "difficulty": 1,
         "topics": ["booleans", "integers", "logic"]
-      },
-      {
-        "slug": "resistor-color",
-        "name": "Resistor Color",
-        "uuid": "c6f41fd5-584c-46ca-b3c5-6a0825446bf4",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": ["arrays", "strings"]
       },
       {
         "slug": "rna-transcription",


### PR DESCRIPTION
`resistor-color` moved before `duo` and `trio` in the series. It makes little sense to have this exercise after the harder ones, if you are doing these exercises sequentially.