### PR TITLE
Fix typo in INSTALLATION.md

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -16,7 +16,7 @@ corepack enable
 
 ## Checking your installation
 
-You generally to to open a new terminal in order to use binaries just installed.
+You generally need to open a new terminal in order to use binaries just installed.
 
 ```shell
 $ node -v

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -16,7 +16,7 @@ corepack enable
 
 ## Checking your installation
 
-You generally need to open a new terminal in order to use binaries just installed.
+You generally need to open a new terminal in order to use binaries you've just installed.
 
 ```shell
 $ node -v


### PR DESCRIPTION
Fixed a grammatical error under `Checking your installation`

`You generally to to open a new terminal...`
=>
`You generally need to open a new terminal...`