### PR TITLE
Do not skip tests

### DIFF
--- a/exercises/practice/two-fer/two-fer.test.ts
+++ b/exercises/practice/two-fer/two-fer.test.ts
@@ -6,12 +6,12 @@ describe('TwoFer', () => {
     expect(twoFer()).toEqual(expected)
   })
 
-  xit('a name given', () => {
+  it('a name given', () => {
     const expected = 'One for Alice, one for me.'
     expect(twoFer('Alice')).toEqual(expected)
   })
 
-  xit('another name given', () => {
+  it('another name given', () => {
     const expected = 'One for Bob, one for me.'
     expect(twoFer('Bob')).toEqual(expected)
   })


### PR DESCRIPTION
Feel free to discard if I misunderstand. I am discovering how tests work!

`xit` skips the tests: https://jestjs.io/docs/api#testskipname-fn.

My impression is that all three tests should be run and therefore use plain it.