### PR TITLE
Add CI step to run `hello-world` exercise as a student would

### DIFF
--- a/.github/workflows/ci.js.yml
+++ b/.github/workflows/ci.js.yml
@@ -49,7 +49,7 @@ jobs:
     # simulating what would happen if a student runs the tests standalone.
     # We do this by removing all project files in the root.
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/ci.js.yml
+++ b/.github/workflows/ci.js.yml
@@ -43,3 +43,34 @@ jobs:
 
       - name: Run exercism/typescript ci (checks config, lint code, and runs tests) for all exercises
         run: yarn ci
+
+  impersonate:
+    # This job tries to run tests for the 'hello-world' exercise, but
+    # simulating what would happen if a student runs the tests standalone.
+    # We do this by removing all project files in the root.
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version: 20.x
+
+      - name: Remove root project files
+        run: rm -f package.json yarn.lock .yarnrc.yml
+
+      - name: Move solution file so that tests pass
+        working-directory: exercises/practice/hello-world
+        run: |
+          rm -f hello-world.ts
+          cp ./.meta/proof.ci.ts hello-world.ts
+
+      - name: Install project dependencies
+        working-directory: exercises/practice/hello-world
+        run: yarn install --no-immutable
+
+      - name: Run tests
+        working-directory: exercises/practice/hello-world
+        run: yarn test

--- a/.github/workflows/pr.ci.js.yml
+++ b/.github/workflows/pr.ci.js.yml
@@ -59,7 +59,7 @@ jobs:
     # simulating what would happen if a student runs the tests standalone.
     # We do this by removing all project files in the root.
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/pr.ci.js.yml
+++ b/.github/workflows/pr.ci.js.yml
@@ -53,3 +53,34 @@ jobs:
           curl --url $"${PULL_REQUEST_URL}/files?per_page=100" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | \
             jq -c '.[] | select(.status == "added" or .status == "modified") | select(.filename | match("\\.(js|jsx|ts|tsx|md|json)$")) | .filename' | \
             xargs -r yarn dlx -p @babel/core -p @babel/node babel-node scripts/pr
+
+  impersonate:
+    # This job tries to run tests for the 'hello-world' exercise, but
+    # simulating what would happen if a student runs the tests standalone.
+    # We do this by removing all project files in the root.
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version: 20.x
+
+      - name: Remove root project files
+        run: rm -f package.json yarn.lock .yarnrc.yml
+
+      - name: Move solution file so that tests pass
+        working-directory: exercises/practice/hello-world
+        run: |
+          rm -f hello-world.ts
+          cp ./.meta/proof.ci.ts hello-world.ts
+
+      - name: Install project dependencies
+        working-directory: exercises/practice/hello-world
+        run: yarn install --no-immutable
+
+      - name: Run tests
+        working-directory: exercises/practice/hello-world
+        run: yarn test


### PR DESCRIPTION
This PR adds a CI step to run the `hello-world` exercise as a student would (and not via the whole project workspace). This allows reproduction of bugs like the one fixed by this PR: #1406 