### PR TITLE
Update test to use `String.prototype.substring()` over `.substr()`

### DIFF
--- a/exercises/practice/robot-name/robot-name.test.ts
+++ b/exercises/practice/robot-name/robot-name.test.ts
@@ -1,10 +1,10 @@
 import { Robot } from './robot-name'
 
 const areSequential = (name1: string, name2: string): boolean => {
-  const alpha1 = name1.substr(0, 2)
-  const alpha2 = name2.substr(0, 2)
-  const num1 = Number(name1.substr(2, 3))
-  const num2 = Number(name2.substr(2, 3))
+  const alpha1 = name1.substring(0, 2)
+  const alpha2 = name2.substring(0, 2)
+  const num1 = Number(name1.substring(2, 5))
+  const num2 = Number(name2.substring(2, 5))
 
   const numDiff = num2 - num1
   const alphaDiff =


### PR DESCRIPTION
`String.prototype.substr()` was deprecated, so the test is refactored to use `String.prototype.slice()` instead.

Edit: Also cleans up formatting with a `yarn format` in the second commit 

(Fixes #1416, it was auto-closed earlier: PR linked in the forum)