### PR TITLE
Add a test for the edge case where the value is an empty string, two-fer

### DIFF
--- a/exercises/practice/two-fer/two-fer.test.ts
+++ b/exercises/practice/two-fer/two-fer.test.ts
@@ -15,4 +15,9 @@ describe('TwoFer', () => {
     const expected = 'One for Bob, one for me.'
     expect(twoFer('Bob')).toEqual(expected)
   })
+
+  xit('empty name given', () => {
+    const expected = 'One for you, one for me.'
+    expect(twoFer('')).toEqual(expected)
+  })
 })


### PR DESCRIPTION
Although it's a very simple exercise, during a mentoring discussion, I found it interesting to consider the possibility of having this additional test, as it's a scenario that could happen in real life where a user might try to pass an empty string value. It's a very simple change; I just added an edge case to the two-fer tests. Feel free to reject this PR if you deem it necessary.