### PR TITLE
Align Instructions with Tests

### DIFF
--- a/exercises/practice/grade-school/.docs/instructions.md
+++ b/exercises/practice/grade-school/.docs/instructions.md
@@ -18,4 +18,4 @@ In the end, you should be able to:
     So the answer is: Anna, Barb, Charlie, Alex, Peter, Zoe and Jim"
 
 Note that all our students only have one name (It's a small town, what do you want?) and each student cannot be added more than once to a grade or the roster.
-In fact, when a test attempts to add the same student more than once, your implementation should indicate that this is incorrect.
+In case someone attempts to add the same student more than once, this student's grade should be updated.


### PR DESCRIPTION
The test currently requires the student is removed from the grade(s) they're first added to and then added to the last one. Since changing the tests to better conform to the instructions would break implementations, I suggest changing the instructions to match the test instead.