### PR TITLE
Updating list-ops test generic types parameters

### DIFF
--- a/exercises/practice/list-ops/list-ops.test.ts
+++ b/exercises/practice/list-ops/list-ops.test.ts
@@ -47,14 +47,14 @@ describe('append entries to a list and return the new list', () => {
   })
 
   xit('list to empty list', () => {
-    const list1 = List.create()
+    const list1 = List.create<number>()
     const list2 = List.create(1, 2, 3, 4)
     expect(list1.append(list2)).toEqual(list2)
   })
 
   xit('empty list to list', () => {
     const list1 = List.create(1, 2, 3, 4)
-    const list2 = List.create()
+    const list2 = List.create<number>()
     expect(list1.append(list2)).toEqual(list1)
   })
 
@@ -75,7 +75,7 @@ describe('concat lists and lists of lists into new list', () => {
   xit('list of lists', () => {
     const list1 = List.create(1, 2)
     const list2 = List.create(3)
-    const list3 = List.create()
+    const list3 = List.create<number>()
     const list4 = List.create(4, 5, 6)
     const listOfLists = List.create(list2, list3, list4)
     expect(list1.concat(listOfLists)).toHaveValues(1, 2, 3, 4, 5, 6)
@@ -84,13 +84,13 @@ describe('concat lists and lists of lists into new list', () => {
 
 describe('filter list returning only values that satisfy the filter function', () => {
   xit('empty list', () => {
-    const list1 = List.create()
-    expect(list1.filter<number>((el) => el % 2 === 1)).toHaveValues()
+    const list1 = List.create<number>()
+    expect(list1.filter((el) => el % 2 === 1)).toHaveValues()
   })
 
   xit('non empty list', () => {
     const list1 = List.create(1, 2, 3, 5)
-    expect(list1.filter<number>((el) => el % 2 === 1)).toHaveValues(1, 3, 5)
+    expect(list1.filter((el) => el % 2 === 1)).toHaveValues(1, 3, 5)
   })
 })
 
@@ -108,47 +108,47 @@ describe('returns the length of a list', () => {
 
 describe('returns a list of elements whose values equal the list value transformed by the mapping function', () => {
   xit('empty list', () => {
-    const list1 = List.create()
-    expect(list1.map<number>((el) => ++el)).toHaveValues()
+    const list1 = List.create<number>()
+    expect(list1.map((el) => ++el)).toHaveValues()
   })
 
   xit('non-empty list', () => {
     const list1 = List.create(1, 3, 5, 7)
-    expect(list1.map<number>((el) => ++el)).toHaveValues(2, 4, 6, 8)
+    expect(list1.map((el) => ++el)).toHaveValues(2, 4, 6, 8)
   })
 })
 
 describe('folds (reduces) the given list from the left with a function', () => {
   xit('empty list', () => {
-    const list1 = List.create()
-    expect(list1.foldl<number, number>((acc, el) => el * acc, 2)).toEqual(2)
+    const list1 = List.create<number>()
+    expect(list1.foldl((acc, el) => el * acc, 2)).toEqual(2)
   })
 
   xit('direction independent function applied to non-empty list', () => {
     const list1 = List.create(1, 2, 3, 4)
-    expect(list1.foldl<number, number>((acc, el) => acc + el, 5)).toEqual(15)
+    expect(list1.foldl((acc, el) => acc + el, 5)).toEqual(15)
   })
 
   xit('direction dependent function applied to non-empty list', () => {
     const list1 = List.create(1, 2, 3, 4)
-    expect(list1.foldl<number, number>((acc, el) => el / acc, 24)).toEqual(64)
+    expect(list1.foldl((acc, el) => el / acc, 24)).toEqual(64)
   })
 })
 
 describe('folds (reduces) the given list from the right with a function', () => {
   xit('empty list', () => {
-    const list1 = List.create()
-    expect(list1.foldr<number, number>((acc, el) => el * acc, 2)).toEqual(2)
+    const list1 = List.create<number>()
+    expect(list1.foldr((acc, el) => el * acc, 2)).toEqual(2)
   })
 
   xit('direction independent function applied to non-empty list', () => {
     const list1 = List.create(1, 2, 3, 4)
-    expect(list1.foldr<number, number>((acc, el) => acc + el, 5)).toEqual(15)
+    expect(list1.foldr((acc, el) => acc + el, 5)).toEqual(15)
   })
 
   xit('direction dependent function applied to non-empty list', () => {
     const list1 = List.create(1, 2, 3, 4)
-    expect(list1.foldr<number, number>((acc, el) => el / acc, 24)).toEqual(9)
+    expect(list1.foldr((acc, el) => el / acc, 24)).toEqual(9)
   })
 })
 


### PR DESCRIPTION
I added and deleted generic type parameters from the list-ops exercise tests.

I did this because I was having problems compiling the code and I also noticed that several generic types were redudant, considering that the `List` class has a generic type like `Array`.

I will list 2 of the changed tests and the reasons why I added or removed the generic type parameter, the other tests were changed for the same reasons:

```ts
/*...*/
xit('list to empty list', () => {
  const list1 = List.create<number>()
  const list2 = List.create(1, 2, 3, 4)
  expect(list1.append(list2)).toEqual(list2)
})
/*...*/
```
In this first test I added the generic type parameter `<number>` to `list1` so that, even though the constant `list1` has no elements, TypeScript understands that it stores the same type value as `list2`. I did not add `<number>` to `list2` because the type of value it stores is automatically deduced by the parameters sent in the `create` function.
___

```ts
/*...*/
describe('filter list returning only values that satisfy the filter function', () => {
  xit('empty list', () => {
    const list1 = List.create<number>()
    expect(list1.filter((el) => el % 2 === 1)).toHaveValues()
  })
/*...*/
```
In this case I understand that `<number>` in `filter` refers to the type of value that the list returned by `filter` will store, however this is not necessary if `List` has a generic type, since the returned list will store the same type of value as the original list.