### PR TITLE
Adding missing test cases to exercise "React"

### DIFF
--- a/exercises/practice/react/react.test.ts
+++ b/exercises/practice/react/react.test.ts
@@ -239,4 +239,26 @@ describe('React module', () => {
 
     expect(values).toEqual([])
   })
+
+  xit('callbacks only fire if related dependencies change', () => {
+    const [input, setInput] = createInput(1)
+    const plusOne = createComputed(() => input() + 1)
+
+    const [input2, _setInput2] = createInput(10)
+    const minusOne = createComputed(() => input2() - 1)
+
+    const plusOneValues: number[] = []
+    createCallback(() => plusOneValues.push(plusOne()))
+    plusOneValues.length = 0 // discard initial values from registration
+
+    const minusOneValues: number[] = []
+    createCallback(() => minusOneValues.push(minusOne()))
+    minusOneValues.length = 0 // discard initial values from registration
+
+    setInput(2)
+    setInput(3)
+
+    expect(plusOneValues).toEqual([3, 4])
+    expect(minusOneValues).toEqual([])
+  })
 })

--- a/exercises/practice/react/react.test.ts
+++ b/exercises/practice/react/react.test.ts
@@ -217,4 +217,26 @@ describe('React module', () => {
 
     expect(values).toEqual([])
   })
+
+  xit("callbacks should not be called if dependencies change but output value doesn't change, even if equality check is enabled on multiple computed", () => {
+    const [input, setInput] = createInput(1)
+    const plusOne = createComputed(() => input() + 1, undefined, true)
+    const minusOne = createComputed(() => input() - 1, undefined, true)
+    const alwaysTwo = createComputed(
+      () => plusOne() - minusOne(),
+      undefined,
+      true // i.e. equality check - don't propagate if value doesn't change
+    )
+
+    const values: number[] = []
+    createCallback(() => values.push(alwaysTwo()))
+    values.pop() // discard initial value from registration
+
+    setInput(2)
+    setInput(3)
+    setInput(4)
+    setInput(5)
+
+    expect(values).toEqual([])
+  })
 })


### PR DESCRIPTION
When browsing through community solutions such as [this one](https://exercism.org/tracks/typescript/exercises/react/solutions/thekaranchauhan), I noticed that the current set of tests allow some shortcuts. Namely, there is two flaws that can be used:

- The tests only ever specify a single computed with an equality check and they only do that on computed that are known to be equal in the test case.
- The tests only specify callbacks that depend on the same input. This allowed solutions to implement a system that fires every callback, regardless which input changed.

The proposed test cases should prevent these shortcuts.