### PR TITLE
Add exercises with type-tests

### DIFF
--- a/common/.meta/test-runner.mjs
+++ b/common/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/common/package.json
+++ b/common/package.json
@@ -17,17 +17,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/common/package.json
+++ b/common/package.json
@@ -31,7 +31,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/common/yarn.lock
+++ b/common/yarn.lock
@@ -1494,7 +1494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@exercism/eslint-config-typescript@npm:^0.7.0":
+"@exercism/eslint-config-typescript@npm:^0.7.1":
   version: 0.7.1
   resolution: "@exercism/eslint-config-typescript@npm:0.7.1"
   dependencies:
@@ -1516,17 +1516,18 @@ __metadata:
   resolution: "@exercism/typescript@workspace:."
   dependencies:
     "@exercism/babel-preset-typescript": "npm:^0.5.0"
-    "@exercism/eslint-config-typescript": "npm:^0.7.0"
+    "@exercism/eslint-config-typescript": "npm:^0.7.1"
     "@jest/globals": "npm:^29.7.0"
-    "@types/node": "npm:~22.0.0"
+    "@types/node": "npm:~22.0.2"
     babel-jest: "npm:^29.7.0"
     core-js: "npm:~3.37.1"
     eslint: "npm:^9.8.0"
     expect: "npm:^29.7.0"
     jest: "npm:^29.7.0"
     prettier: "npm:^3.3.3"
+    tstyche: "npm:^2.1.1"
     typescript: "npm:~5.5.4"
-    typescript-eslint: "npm:^7.17.0"
+    typescript-eslint: "npm:^7.18.0"
   languageName: unknown
   linkType: soft
 
@@ -2057,12 +2058,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:~22.0.0":
+"@types/node@npm:*":
   version: 22.0.0
   resolution: "@types/node@npm:22.0.0"
   dependencies:
     undici-types: "npm:~6.11.1"
   checksum: 10/7142a13ef1f884fde38f1e1499cbebcfe72755e8cb8657c4cb1ba1c2c91a3ae8656a72eb6e0a7d8189b0124c23c30e7c115324375d9c593435166da7a292e80e
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:~22.0.2":
+  version: 22.0.2
+  resolution: "@types/node@npm:22.0.2"
+  dependencies:
+    undici-types: "npm:~6.11.1"
+  checksum: 10/7f5937f22d5171df6d1764b838b64f03fd2686e0ebee15bb64eb609ee5280cfd8cbbb78efdf163bb49eee11c77de461ef8b85e2781e508d231777390ddf0e8ec
   languageName: node
   linkType: hard
 
@@ -6115,6 +6125,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tstyche@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "tstyche@npm:2.1.1"
+  peerDependencies:
+    typescript: 4.x || 5.x
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tstyche: ./build/bin.js
+  checksum: 10/f30e7d782e51c262528ededf383c9daf39af8dea063d483667e3ff9f4800434891589c294c4b4f69802dd06daf8fb1d2a10553316d2f4631ba1413d3e48dab81
+  languageName: node
+  linkType: hard
+
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -6190,7 +6214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^7.17.0":
+"typescript-eslint@npm:^7.17.0, typescript-eslint@npm:^7.18.0":
   version: 7.18.0
   resolution: "typescript-eslint@npm:7.18.0"
   dependencies:

--- a/common/yarn.lock
+++ b/common/yarn.lock
@@ -312,24 +312,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.25.0":
-  version: 7.25.0
-  resolution: "@babel/parser@npm:7.25.0"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.25.0, @babel/parser@npm:^7.25.3":
+  version: 7.25.3
+  resolution: "@babel/parser@npm:7.25.3"
+  dependencies:
+    "@babel/types": "npm:^7.25.2"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 10/1860179256b5e04259a1d567dc43470306757f51c515bedd6fc92dc5f8b4c4a6582c0b1f89a90fd4e981430195b727348d50c890b21c7eb84871248884771aaf
+  checksum: 10/7bd57e89110bdc9cffe0ef2f2286f1cfb9bbb3aa1d9208c287e0bf6a1eb4cfe6ab33958876ebc59aafcbe3e2381c4449240fc7cc2ff32b79bc9db89cd52fc779
   languageName: node
   linkType: hard
 
-"@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:^7.25.0":
-  version: 7.25.0
-  resolution: "@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:7.25.0"
+"@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:^7.25.3":
+  version: 7.25.3
+  resolution: "@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:7.25.3"
   dependencies:
     "@babel/helper-plugin-utils": "npm:^7.24.8"
-    "@babel/traverse": "npm:^7.25.0"
+    "@babel/traverse": "npm:^7.25.3"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10/9befa15787d9dd0abba6a84e2c8a40d798241cbe00d186ad453bcf91342fe5dd0f6882a246bb209c9bd5d2f0b914d83850e1dcf99e144a45fe7918538ef40020
+  checksum: 10/9743feb0152f2ac686aaee6dfd41e8ea211989a459d4c2b10b531442f6865057cd1a502515634c25462b155bc58f0710267afed72396780e9b72be25370dd577
   languageName: node
   linkType: hard
 
@@ -1226,14 +1228,14 @@ __metadata:
   linkType: hard
 
 "@babel/preset-env@npm:^7.25.0":
-  version: 7.25.2
-  resolution: "@babel/preset-env@npm:7.25.2"
+  version: 7.25.3
+  resolution: "@babel/preset-env@npm:7.25.3"
   dependencies:
     "@babel/compat-data": "npm:^7.25.2"
     "@babel/helper-compilation-targets": "npm:^7.25.2"
     "@babel/helper-plugin-utils": "npm:^7.24.8"
     "@babel/helper-validator-option": "npm:^7.24.8"
-    "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "npm:^7.25.0"
+    "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "npm:^7.25.3"
     "@babel/plugin-bugfix-safari-class-field-initializer-scope": "npm:^7.25.0"
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "npm:^7.25.0"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "npm:^7.24.7"
@@ -1314,7 +1316,7 @@ __metadata:
     semver: "npm:^6.3.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10/78796a561a0f363b59f9d1ef0162a738a87340c9b3c9ad9ace1936bcf1295f1ef082179f3d2f8d603570e60ba30315eaa69284095b22e4f570f37607556db820
+  checksum: 10/293c32dee33f138d22cea0c0e163b6d79ef3860ac269921a438edb4adbfa53976ce2cd3f7a79408c8e52c852b5feda45abdbc986a54e9d9aa0b6680d7a371a58
   languageName: node
   linkType: hard
 
@@ -1388,22 +1390,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.24.7, @babel/traverse@npm:^7.24.8, @babel/traverse@npm:^7.25.0, @babel/traverse@npm:^7.25.1, @babel/traverse@npm:^7.25.2":
-  version: 7.25.2
-  resolution: "@babel/traverse@npm:7.25.2"
+"@babel/traverse@npm:^7.24.7, @babel/traverse@npm:^7.24.8, @babel/traverse@npm:^7.25.0, @babel/traverse@npm:^7.25.1, @babel/traverse@npm:^7.25.2, @babel/traverse@npm:^7.25.3":
+  version: 7.25.3
+  resolution: "@babel/traverse@npm:7.25.3"
   dependencies:
     "@babel/code-frame": "npm:^7.24.7"
     "@babel/generator": "npm:^7.25.0"
-    "@babel/parser": "npm:^7.25.0"
+    "@babel/parser": "npm:^7.25.3"
     "@babel/template": "npm:^7.25.0"
     "@babel/types": "npm:^7.25.2"
     debug: "npm:^4.3.1"
     globals: "npm:^11.1.0"
-  checksum: 10/d563863ab33130254e336e3d15ca13006effdefe67b7058f3eab8c0f13c76f09f6708d95769be926e0f500d3836e91a56eb78133ebf19916d651ab6e725be000
+  checksum: 10/fba34f323e17fa83372fc290bc12413a50e2f780a86c7d8b1875c594b6be2857867804de5d52ab10a78a9cae29e1b09ea15d85ad63671ce97d79c40650282bb9
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.24.7, @babel/types@npm:^7.24.8, @babel/types@npm:^7.25.0, @babel/types@npm:^7.25.2, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.24.7, @babel/types@npm:^7.24.8, @babel/types@npm:^7.25.0, @babel/types@npm:^7.25.2, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.25.2
   resolution: "@babel/types@npm:7.25.2"
   dependencies:
@@ -1932,9 +1934,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin-js@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@stylistic/eslint-plugin-js@npm:2.4.0"
+"@stylistic/eslint-plugin-js@npm:2.6.0":
+  version: 2.6.0
+  resolution: "@stylistic/eslint-plugin-js@npm:2.6.0"
   dependencies:
     "@types/eslint": "npm:^9.6.0"
     acorn: "npm:^8.12.1"
@@ -1942,20 +1944,20 @@ __metadata:
     espree: "npm:^10.1.0"
   peerDependencies:
     eslint: ">=8.40.0"
-  checksum: 10/9efccd6c59404f8ec2cc93261380df1c60126ee1f7972456e3f1501ab1d5387f93ea8a83d2e8910c9788cfc262837af85bd4dabf6052474afa5bf6a0e9cd1016
+  checksum: 10/95e7604769cc9a914c50ac52dc9b136c8e66cb2f183b64acf4571b91dc272e2170bfd7293d937a60a2a5c5892f617a233eeca009af32263e305f53b8a14077d3
   languageName: node
   linkType: hard
 
 "@stylistic/eslint-plugin-ts@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "@stylistic/eslint-plugin-ts@npm:2.4.0"
+  version: 2.6.0
+  resolution: "@stylistic/eslint-plugin-ts@npm:2.6.0"
   dependencies:
-    "@stylistic/eslint-plugin-js": "npm:2.4.0"
+    "@stylistic/eslint-plugin-js": "npm:2.6.0"
     "@types/eslint": "npm:^9.6.0"
-    "@typescript-eslint/utils": "npm:^7.17.0"
+    "@typescript-eslint/utils": "npm:^8.0.0"
   peerDependencies:
     eslint: ">=8.40.0"
-  checksum: 10/c613fe011c88cba84217afcb3016f631eaec556a4ac464b7c48312067d37e10875377a369b2477f3b7a0e3aa0edb5e17ce7d39ab86bc3928f0fb5b738125e878
+  checksum: 10/ca88e326b9c3f107191aec49d299e0bbb5c29ad1703c00b0ada22c7457a331b8c6f5a3431b06918b006a6bf1bd30e36633c80ca61ce9f21ee23571b886849122
   languageName: node
   linkType: hard
 
@@ -2058,16 +2060,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 22.0.0
-  resolution: "@types/node@npm:22.0.0"
-  dependencies:
-    undici-types: "npm:~6.11.1"
-  checksum: 10/7142a13ef1f884fde38f1e1499cbebcfe72755e8cb8657c4cb1ba1c2c91a3ae8656a72eb6e0a7d8189b0124c23c30e7c115324375d9c593435166da7a292e80e
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:~22.0.2":
+"@types/node@npm:*, @types/node@npm:~22.0.2":
   version: 22.0.2
   resolution: "@types/node@npm:22.0.2"
   dependencies:
@@ -2150,6 +2143,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.0.0":
+  version: 8.0.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.0.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.0.0"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0"
+  checksum: 10/444dbc156d9d6d2aa4f82e35ab171aed85d1818c5adf70f955f69d6d0591d9a0668f645d38bf5b759098849aa4114340ca128a673be5525a94fba9a048751d0c
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:7.18.0":
   version: 7.18.0
   resolution: "@typescript-eslint/type-utils@npm:7.18.0"
@@ -2174,6 +2177,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:8.0.0":
+  version: 8.0.0
+  resolution: "@typescript-eslint/types@npm:8.0.0"
+  checksum: 10/e28e79d8b7acfa42c90781fa63e90e56807ae018a0a92fc71c8e441d2bb3a250527c9d44ff6450ff1d47ceed0c3df28de6599f97f6c4c65ac554088867fc3517
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/typescript-estree@npm:7.18.0":
   version: 7.18.0
   resolution: "@typescript-eslint/typescript-estree@npm:7.18.0"
@@ -2193,7 +2203,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:7.18.0, @typescript-eslint/utils@npm:^6.0.0 || ^7.0.0, @typescript-eslint/utils@npm:^7.17.0":
+"@typescript-eslint/typescript-estree@npm:8.0.0":
+  version: 8.0.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.0.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.0.0"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0"
+    debug: "npm:^4.3.4"
+    globby: "npm:^11.1.0"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^1.3.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/99a80fb43d1e9cbd49a3dfdd264e7e361ffd4e19970d2b04b86a551fc730cc4f19202c3323d0d6bbfd7ce4672bf205cb7b756ba2e20c95729b24e878b96e66f3
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:7.18.0, @typescript-eslint/utils@npm:^6.0.0 || ^7.0.0":
   version: 7.18.0
   resolution: "@typescript-eslint/utils@npm:7.18.0"
   dependencies:
@@ -2207,6 +2236,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@typescript-eslint/utils@npm:8.0.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@typescript-eslint/scope-manager": "npm:8.0.0"
+    "@typescript-eslint/types": "npm:8.0.0"
+    "@typescript-eslint/typescript-estree": "npm:8.0.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+  checksum: 10/f76e65763725d944d3c6f0e78ea566cdb08247fa7ee9e2ec15310527f3e2325c92cb67c80a63e4a6dd29a5a7d96db3839aebd0a2e98810dcc248f6762414c995
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:7.18.0":
   version: 7.18.0
   resolution: "@typescript-eslint/visitor-keys@npm:7.18.0"
@@ -2214,6 +2257,16 @@ __metadata:
     "@typescript-eslint/types": "npm:7.18.0"
     eslint-visitor-keys: "npm:^3.4.3"
   checksum: 10/b7cfe6fdeae86c507357ac6b2357813c64fb2fbf1aaf844393ba82f73a16e2599b41981b34200d9fc7765d70bc3a8181d76b503051e53f04bcb7c9afef637eab
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.0.0":
+  version: 8.0.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.0.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.0.0"
+    eslint-visitor-keys: "npm:^3.4.3"
+  checksum: 10/328106878ed42f1543590317477275a3c95c0455ba8203355fede94b0970844ec430cc5e090d4e1f48d805ac40ab1bd339270514e256b0810cabd423c6b2d52a
   languageName: node
   linkType: hard
 
@@ -2643,9 +2696,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001640":
-  version: 1.0.30001644
-  resolution: "caniuse-lite@npm:1.0.30001644"
-  checksum: 10/39a55adddd5e199e9f49edb853fe3ab4f267f2efd2a28c85ebffb280f0a775b7fc8faf0963a60232d7f5623aae012bd94c7830a256bad0d4a4eeb15610fac1af
+  version: 1.0.30001645
+  resolution: "caniuse-lite@npm:1.0.30001645"
+  checksum: 10/a59d80e5a1f062e0ede67d57c901144a1ecb4c093f58a34438cecdb6be4feaadd8017db86c3a95e6a73cef363a8c68c31fca772ff29b3d0d0db4e2aa66722a96
   languageName: node
   linkType: hard
 
@@ -2969,9 +3022,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.820":
-  version: 1.5.3
-  resolution: "electron-to-chromium@npm:1.5.3"
-  checksum: 10/f0cf761556978f6d627d5f6f704ce98fdc24ab230f3c6685940fa98dbaf0afe340a003f8ecc89f59d590cbcec0a415f8dffdf28dab71fa7f33555cb407d0ac64
+  version: 1.5.4
+  resolution: "electron-to-chromium@npm:1.5.4"
+  checksum: 10/ce64db25c399d33830e74e58bbc5ab7c06948669e204b6508e98c278ddaead1da1cbb356d15b55eb659f89d4d7bcf00944f08f96e886f1d3d065ba11744c5633
   languageName: node
   linkType: hard
 

--- a/concepts/basics/.meta/config.json
+++ b/concepts/basics/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "Basics contains the minimal knowledge required to get started in TypeScript: function declarations, variable assignment, and exposing entities.",
+  "authors": ["SleeplessByte"],
+  "contributors": ["junedev"]
+}

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -49,7 +49,10 @@ Because TypeScript can detect this statically, the TypeScript compiler will also
 
 This means you don't need to run the code to detect the `TypeError`.
 
-> 💡 In a later Learning Exercise, the difference between _constant_ assignment / binding and _constant_ value is explored and explained.
+<!--prettier-ignore -->
+~~~~exercism/note
+💡 In a later Learning Exercise, the difference between _constant_ assignment / binding and _constant_ value is explored and explained.
+~~~~
 
 ## Type inference
 
@@ -149,10 +152,13 @@ add(1, 3)
 
 Here the return type was inferred because TypeScript knows that the result of `number + number` must always be `number`.
 
-> 💡 In TypeScript there are _many_ different ways to declare a function.
-> These other ways look different than using the `function` keyword.
-> The track tries to gradually introduce them, but if you already know about them, feel free to use any of them.
-> In most cases, using one or the other isn't better or worse.
+<!--prettier-ignore -->
+~~~~exercism/note
+💡 In TypeScript there are _many_ different ways to declare a function.
+These other ways look different than using the `function` keyword.
+The track tries to gradually introduce them, but if you already know about them, feel free to use any of them.
+In most cases, using one or the other isn't better or worse.
+~~~~
 
 ## Type Annotations
 
@@ -198,11 +204,14 @@ add(MY_VALUE, 5)
 // => 15
 ```
 
+<!--prettier-ignore -->
+~~~~exercism/advanced
 Because the TypeScript compiler does _not rewrite import paths_, the imports should be written using the `.js` extension (as that's what it will become after transpilation).
 However, the option `allowImportingTsExtensions` is on because we have a process that rewrites the paths.
 This allows importing from `.ts` (as well as `.js`).
 
 In older code you will find imports _without file extension_.
+~~~~
 
 [blog-live-bindings]: https://2ality.com/2015/07/es6-module-exports.html#es6-modules-export-immutable-bindings
 [blog-tree-shaking]: https://bitsofco.de/what-is-tree-shaking/

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -1,0 +1,116 @@
+# About
+
+TypeScript is a dynamic, prototype-based language. It has a few [primitives][mdn-primitive], and everything else is considered an object.
+
+While it is most well-known as the scripting language for Web pages, many non-browser environments also use it, such as Node.js. The language is actively being developed; and because of its multi-paradigm property, allows for many styles of programming. TypeScript is a dynamic language, supporting object-oriented, imperative, and declarative (e.g. functional programming) styles.
+
+## (Re-)Assignment
+
+There are a few primary ways to assign values to names in TypeScript - using variables or constants. On Exercism, variables are always written in [camelCase][wiki-camel-case]; constants are written in [SCREAMING_SNAKE_CASE][wiki-snake-case]. There is no official guide to follow, and various companies and organizations have various style guides. _Feel free to write variables any way you like_. The upside from writing them the way the exercises are prepared is that they'll be highlighted differently in the web interface and most IDEs.
+
+Variables in TypeScript can be defined using the [`const`][mdn-const], [`let`][mdn-let] or [`var`][mdn-var] keyword.
+
+A variable can reference different values over its lifetime when using `let` or `var`. For example, `myFirstVariable` can be defined and redefined many times using the assignment operator `=`:
+
+```typescript
+let myFirstVariable = 1
+myFirstVariable = 'Some string'
+myFirstVariable = new SomeComplexClass()
+```
+
+In contrast to `let` and `var`, variables that are defined with `const` can only be assigned once. This is used to define constants in TypeScript.
+
+```typescript
+const MY_FIRST_CONSTANT = 10
+
+// Can not be re-assigned.
+MY_FIRST_CONSTANT = 20
+// => TypeError: Assignment to constant variable.
+```
+
+### Constant Assignment
+
+The `const` keyword is mentioned _both_ for variables and constants. Another concept often mentioned around constants is [(im)-mutability][wiki-mutability].
+
+The `const` keyword only makes the _binding_ immutable, that is, you can only assign a value to a `const` variable once. In TypeScript, only [primitive][mdn-primitive] values are immutable. However, [non-primitive][mdn-primitive] values can still be mutated.
+
+```typescript
+const MY_MUTABLE_VALUE_CONSTANT = { food: 'apple' }
+
+// This is possible
+MY_MUTABLE_VALUE_CONSTANT.food = 'pear'
+
+MY_MUTABLE_VALUE_CONSTANT
+// => { food: "pear" }
+```
+
+### Constant Value (Immutability)
+
+As a rule, on Exercism, and many other organizations and project style guides, don't mutate values that look like `const SCREAMING_SNAKE_CASE`. Technically the values _can_ be changed, but for clarity and expectation management on Exercism this is discouraged. When this _must_ be enforced, use [`Object.freeze(value)`][mdn-object-freeze].
+
+```typescript
+const MY_VALUE_CONSTANT = Object.freeze({ food: 'apple' })
+
+// This silently fails
+MY_VALUE_CONSTANT.food = 'pear'
+
+MY_VALUE_CONSTANT
+// => { food: "apple" }
+```
+
+In the wild, it's unlikely to see `Object.freeze` all over a code base, but the rule to not mutate a `SCREAMING_SNAKE_CASE` value ever, is a good rule; often enforced using automated analysis such as a linter.
+
+## Function Declarations
+
+In TypeScript, units of functionality are encapsulated in _functions_, usually grouping functions together in the same file if they belong together. These functions can take parameters (arguments), and can _return_ a value using the `return` keyword. Functions are invoked using `()` syntax.
+
+```typescript
+function add(num1, num2) {
+  return num1 + num2
+}
+
+add(1, 3)
+// => 4
+```
+
+> 💡 In TypeScript there are _many_ different ways to declare a function. These other ways look different than using the `function` keyword. The track tries to gradually introduce them, but if you already know about them, feel free to use any of them. In most cases, using one or the other isn't better or worse.
+
+## Export and Import
+
+The `export` and `import` keywords are powerful tools that turn a regular TypeScript file into a [TypeScript module][mdn-module]. Apart from allowing code to selectively expose components, such as functions, classes, variables and constants, it also enables a whole range of other features, such as:
+
+- [Renaming exports and imports][mdn-renaming-modules], which allows you to avoid naming conflicts,
+- [Dynamic Imports][mdn-dynamic-imports], which loads code on demand,
+- [Tree shaking][blog-tree-shaking], which reduces the size of the final code by eliminating side-effect free modules and even contents of modules _that are not used_,
+- Exporting [_live bindings_][blog-live-bindings], which allows you to export a value that mutates everywhere it's imported if the original value mutates.
+
+A concrete example is how the tests work on Exercism's TypeScript Track. Each exercise has at least one implementation file, for example `lasagna.js`, and each exercise has at least one test file, for example `lasagna.spec.js`. The implementation file uses `export` to expose the public API and the test file uses `import` to access these, which is how it can test the implementation's outcomes.
+
+```typescript
+// file.js
+export const MY_VALUE = 10
+
+export function add(num1, num2) {
+  return num1 + num2
+}
+
+// file.spec.js
+import { MY_VALUE, add } from './file'
+
+add(MY_VALUE, 5)
+// => 15
+```
+
+[blog-live-bindings]: https://2ality.com/2015/07/es6-module-exports.html#es6-modules-export-immutable-bindings
+[blog-tree-shaking]: https://bitsofco.de/what-is-tree-shaking/
+[mdn-const]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const
+[mdn-dynamic-imports]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Imports
+[mdn-let]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let
+[mdn-module]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules
+[mdn-object-freeze]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
+[mdn-primitive]: https://developer.mozilla.org/en-US/docs/Glossary/Primitive
+[mdn-renaming-modules]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#Renaming_imports_and_exports
+[mdn-var]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var
+[wiki-mutability]: https://en.wikipedia.org/wiki/Immutable_object
+[wiki-camel-case]: https://en.wikipedia.org/wiki/Camel_case
+[wiki-snake-case]: https://en.wikipedia.org/wiki/Snake_case

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -1,16 +1,28 @@
 # About
 
-TypeScript is a dynamic, prototype-based language. It has a few [primitives][mdn-primitive], and everything else is considered an object.
+TypeScript is JavaScript with syntax for types, making it a a strongly typed programming language, supporting object-oriented, imperative, and declarative (e.g. functional programming) styles, giving you better tooling at any scale.
+It has a few [primitives][mdn-primitive], and everything else is considered an object.
 
-While it is most well-known as the scripting language for Web pages, many non-browser environments also use it, such as Node.js. The language is actively being developed; and because of its multi-paradigm property, allows for many styles of programming. TypeScript is a dynamic language, supporting object-oriented, imperative, and declarative (e.g. functional programming) styles.
+While JavaScript is the most well-known as the scripting language for Web pages, many non-browser environments also use it, such as Node.js.
+The language is actively being developed; and because of its multi-paradigm property, allows for many styles of programming.
+
+TypeScript builds on-top of this and is also actively developed.
+In some rankings from 2023 it is more popular than JavaScript in daily use.
+
+Because [you cannot learn TypeScript without learning JavaScript][handbook-js-or-ts], some of the content in this Track is focused on teaching JavaScript concepts and some of the concepts focus on TypeScript specific features only.
 
 ## (Re-)Assignment
 
-There are a few primary ways to assign values to names in TypeScript - using variables or constants. On Exercism, variables are always written in [camelCase][wiki-camel-case]; constants are written in [SCREAMING_SNAKE_CASE][wiki-snake-case]. There is no official guide to follow, and various companies and organizations have various style guides. _Feel free to write variables any way you like_. The upside from writing them the way the exercises are prepared is that they'll be highlighted differently in the web interface and most IDEs.
+There are a few primary ways to assign values to names in TypeScript - using variables or constants.
+On Exercism, variables are always written in [camelCase][wiki-camel-case]; constants are written in [SCREAMING_SNAKE_CASE][wiki-snake-case].
+There is no official guide to follow, and various companies and organizations have various style guides.
+_Feel free to write variables any way you like_.
+The upside from writing them the way the exercises are prepared is that they'll be highlighted differently in the web interface and most IDEs.
 
 Variables in TypeScript can be defined using the [`const`][mdn-const], [`let`][mdn-let] or [`var`][mdn-var] keyword.
 
-A variable can reference different values over its lifetime when using `let` or `var`. For example, `myFirstVariable` can be defined and redefined many times using the assignment operator `=`:
+A variable can reference different values over its lifetime when using `let` or `var`.
+For example, `myFirstVariable` can be defined and redefined many times using the assignment operator `=`:
 
 ```typescript
 let myFirstVariable = 1
@@ -18,7 +30,8 @@ myFirstVariable = 'Some string'
 myFirstVariable = new SomeComplexClass()
 ```
 
-In contrast to `let` and `var`, variables that are defined with `const` can only be assigned once. This is used to define constants in TypeScript.
+In contrast to `let` and `var`, variables that are defined with `const` can only be assigned once.
+This is used to define constants in TypeScript.
 
 ```typescript
 const MY_FIRST_CONSTANT = 10
@@ -28,11 +41,51 @@ MY_FIRST_CONSTANT = 20
 // => TypeError: Assignment to constant variable.
 ```
 
+Because TypeScript can detect this statically, the TypeScript compiler will also yield an error:
+
+```typescript
+// ^? Cannot assign to 'MY_FIRST_CONSTANT' because it is a constant.(2588)
+```
+
+This means you don't need to run the code to detect the `TypeError`.
+
+> 💡 In a later Learning Exercise, the difference between _constant_ assignment / binding and _constant_ value is explored and explained.
+
+## Type inference
+
+Without diving too deep into the subject of [type inference][handbook-type-inference], you should be aware that an assigned variable usually as an inferred type, even without a type annotation.
+
+```typescript
+const MY_FIRST_CONSTANT = 10
+// ^? const MY_FIRST_CONSTANT: number
+```
+
+This type is then enforced throughout the code.
+This also means that where the following code is valid JavaScript:
+
+```javascript
+let myFirstVariable = 1
+myFirstVariable = 'Some string'
+```
+
+It complains when using TypeScript:
+
+```typescript
+let myFirstVariable = 1
+myFirstVariable = 'Some string'
+// ^? Type 'string' is not assignable to type 'number'.(2322)
+```
+
+This feature ensures type-safety even when type annotations are not used.
+
 ### Constant Assignment
 
-The `const` keyword is mentioned _both_ for variables and constants. Another concept often mentioned around constants is [(im)-mutability][wiki-mutability].
+The `const` keyword is mentioned _both_ for variables and constants.
+Another concept often mentioned around constants is [(im)-mutability][wiki-mutability].
 
-The `const` keyword only makes the _binding_ immutable, that is, you can only assign a value to a `const` variable once. In TypeScript, only [primitive][mdn-primitive] values are immutable. However, [non-primitive][mdn-primitive] values can still be mutated.
+The `const` keyword only makes the _binding_ immutable, that is, you can only assign a value to a `const` variable once.
+In TypeScript, only [primitive][mdn-primitive] values are immutable.
+However, [non-primitive][mdn-primitive] values can still be mutated.
 
 ```typescript
 const MY_MUTABLE_VALUE_CONSTANT = { food: 'apple' }
@@ -46,13 +99,18 @@ MY_MUTABLE_VALUE_CONSTANT
 
 ### Constant Value (Immutability)
 
-As a rule, on Exercism, and many other organizations and project style guides, don't mutate values that look like `const SCREAMING_SNAKE_CASE`. Technically the values _can_ be changed, but for clarity and expectation management on Exercism this is discouraged. When this _must_ be enforced, use [`Object.freeze(value)`][mdn-object-freeze].
+As a rule, on Exercism, and many other organizations and project style guides, don't mutate values that look like `const SCREAMING_SNAKE_CASE`.
+Technically the values _can_ be changed, but for clarity and expectation management on Exercism this is discouraged.
+When this _must_ be enforced, use [`Object.freeze(value)`][mdn-object-freeze].
+
+Where possible, the TypeScript keyword `readonly`, `as const`, or `Readonly<T>` generic type may be used to enforce immutability statically.
+You will learn more about this subject later.
 
 ```typescript
 const MY_VALUE_CONSTANT = Object.freeze({ food: 'apple' })
 
-// This silently fails
 MY_VALUE_CONSTANT.food = 'pear'
+// ^? Cannot assign to 'food' because it is a read-only property.(2540)
 
 MY_VALUE_CONSTANT
 // => { food: "apple" }
@@ -62,10 +120,12 @@ In the wild, it's unlikely to see `Object.freeze` all over a code base, but the 
 
 ## Function Declarations
 
-In TypeScript, units of functionality are encapsulated in _functions_, usually grouping functions together in the same file if they belong together. These functions can take parameters (arguments), and can _return_ a value using the `return` keyword. Functions are invoked using `()` syntax.
+In TypeScript, units of functionality are encapsulated in _functions_, usually grouping functions together in the same file if they belong together.
+These functions can take parameters (arguments), and can _return_ a value using the `return` keyword.
+Functions are invoked using `()` syntax.
 
 ```typescript
-function add(num1, num2) {
+function add(num1: number, num2: number): number {
   return num1 + num2
 }
 
@@ -73,18 +133,55 @@ add(1, 3)
 // => 4
 ```
 
-> 💡 In TypeScript there are _many_ different ways to declare a function. These other ways look different than using the `function` keyword. The track tries to gradually introduce them, but if you already know about them, feel free to use any of them. In most cases, using one or the other isn't better or worse.
+Function parameters should usually be annotated with a type using a colon (`:`) followed by the type.
+Function return values can be annotated after closing the parameter list using a colon (`:`) followed by the type.
+
+If a function does not have a type annotation for its return value, the type will be inferred.
+
+```typescript
+function add(num1: number, num2: number) {
+  return num1 + num2
+}
+
+add(1, 3)
+// ^? function add(num1: number, num2: number): number
+```
+
+Here the return type was inferred because TypeScript knows that the result of `number + number` must always be `number`.
+
+> 💡 In TypeScript there are _many_ different ways to declare a function.
+> These other ways look different than using the `function` keyword.
+> The track tries to gradually introduce them, but if you already know about them, feel free to use any of them.
+> In most cases, using one or the other isn't better or worse.
+
+## Type Annotations
+
+As shown in the function declaration for `add`, the parameters have an explicit type annotation `: number`.
+Variable declarations, class properties, function declarations and more all support type annotations.
+
+Both explicit type annotation as inferred types are enforced by the type-checker.
+
+```typescript
+add('foo', 3)
+// ^? Argument of type 'string' is not assignable to parameter of type 'number'.(2345)
+```
+
+If TypeScript does not find an explicit type annotation and cannot infer the type, it will assign the `any` type, which [you should not use][handbook-dont-use-any].
+Later you will learn about the `unknown` type as a good alternative.
 
 ## Export and Import
 
-The `export` and `import` keywords are powerful tools that turn a regular TypeScript file into a [TypeScript module][mdn-module]. Apart from allowing code to selectively expose components, such as functions, classes, variables and constants, it also enables a whole range of other features, such as:
+The `export` and `import` keywords are powerful tools that turn a regular TypeScript file into a [TypeScript module][mdn-module].
+Apart from allowing code to selectively expose components, such as functions, classes, variables and constants, it also enables a whole range of other features, such as:
 
 - [Renaming exports and imports][mdn-renaming-modules], which allows you to avoid naming conflicts,
 - [Dynamic Imports][mdn-dynamic-imports], which loads code on demand,
 - [Tree shaking][blog-tree-shaking], which reduces the size of the final code by eliminating side-effect free modules and even contents of modules _that are not used_,
 - Exporting [_live bindings_][blog-live-bindings], which allows you to export a value that mutates everywhere it's imported if the original value mutates.
 
-A concrete example is how the tests work on Exercism's TypeScript Track. Each exercise has at least one implementation file, for example `lasagna.js`, and each exercise has at least one test file, for example `lasagna.spec.js`. The implementation file uses `export` to expose the public API and the test file uses `import` to access these, which is how it can test the implementation's outcomes.
+A concrete example is how the tests work on Exercism's TypeScript Track.
+Each exercise has at least one implementation file, for example `lasagna.ts`, and each exercise has at least one test file, for example `lasagna.test.ts`.
+The implementation file uses `export` to expose the public API and the test file uses `import` to access these, which is how it can test the implementation's outcomes.
 
 ```typescript
 // file.js
@@ -95,11 +192,17 @@ export function add(num1, num2) {
 }
 
 // file.spec.js
-import { MY_VALUE, add } from './file'
+import { MY_VALUE, add } from './file.js'
 
 add(MY_VALUE, 5)
 // => 15
 ```
+
+Because the TypeScript compiler does _not rewrite import paths_, the imports should be written using the `.js` extension (as that's what it will become after transpilation).
+However, the option `allowImportingTsExtensions` is on because we have a process that rewrites the paths.
+This allows importing from `.ts` (as well as `.js`).
+
+In older code you will find imports _without file extension_.
 
 [blog-live-bindings]: https://2ality.com/2015/07/es6-module-exports.html#es6-modules-export-immutable-bindings
 [blog-tree-shaking]: https://bitsofco.de/what-is-tree-shaking/
@@ -111,6 +214,9 @@ add(MY_VALUE, 5)
 [mdn-primitive]: https://developer.mozilla.org/en-US/docs/Glossary/Primitive
 [mdn-renaming-modules]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#Renaming_imports_and_exports
 [mdn-var]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var
+[handbook-dont-use-any]: https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#any
+[handbook-js-or-ts]: https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html#learning-javascript-and-typescript
+[handbook-type-inference]: https://www.typescriptlang.org/docs/handbook/type-inference.html
 [wiki-mutability]: https://en.wikipedia.org/wiki/Immutable_object
 [wiki-camel-case]: https://en.wikipedia.org/wiki/Camel_case
 [wiki-snake-case]: https://en.wikipedia.org/wiki/Snake_case

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -1,0 +1,71 @@
+# Introduction
+
+TypeScript is a dynamic language, supporting object-oriented, imperative, and declarative (e.g. functional programming) styles.
+
+## (Re-)Assignment
+
+There are a few primary ways to assign values to names in TypeScript - using variables or constants. On Exercism, variables are always written in [camelCase][wiki-camel-case]; constants are written in [SCREAMING_SNAKE_CASE][wiki-snake-case]. There is no official guide to follow, and various companies and organizations have various style guides. _Feel free to write variables any way you like_. The upside from writing them the way the exercises are prepared is that they'll be highlighted differently in the web interface and most IDEs.
+
+Variables in TypeScript can be defined using the [`const`][mdn-const], [`let`][mdn-let] or [`var`][mdn-var] keyword.
+
+A variable can reference different values over its lifetime when using `let` or `var`. For example, `myFirstVariable` can be defined and redefined many times using the assignment operator `=`:
+
+```typescript
+let myFirstVariable = 1
+myFirstVariable = 'Some string'
+myFirstVariable = new SomeComplexClass()
+```
+
+In contrast to `let` and `var`, variables that are defined with `const` can only be assigned once. This is used to define constants in TypeScript.
+
+```typescript
+const MY_FIRST_CONSTANT = 10
+
+// Can not be re-assigned.
+MY_FIRST_CONSTANT = 20
+// => TypeError: Assignment to constant variable.
+```
+
+> 💡 In a later Learning Exercise, the difference between _constant_ assignment / binding and _constant_ value is explored and explained.
+
+## Function Declarations
+
+In TypeScript, units of functionality are encapsulated in _functions_, usually grouping functions together in the same file if they belong together. These functions can take parameters (arguments), and can _return_ a value using the `return` keyword. Functions are invoked using `()` syntax.
+
+```typescript
+function add(num1, num2) {
+  return num1 + num2
+}
+
+add(1, 3)
+// => 4
+```
+
+> 💡 In TypeScript there are _many_ different ways to declare a function. These other ways look different than using the `function` keyword. The track tries to gradually introduce them, but if you already know about them, feel free to use any of them. In most cases, using one or the other isn't better or worse.
+
+## Exposing to Other Files
+
+To make a `function`, a constant, or a variable available in _other files_, they need to be [exported][mdn-export] using the `export` keyword. Another file may then [import][mdn-import] these using the `import` keyword. This is also known as the module system. A great example is how all the tests work. Each exercise has at least one file, for example `lasagna.js`, which contains the _implementation_. Additionally, there is at least one other file, for example `lasagna.spec.js`, that contains the _tests_. This file _imports_ the public (i.e. exported) entities to test the implementation:
+
+```typescript
+// file.js
+export const MY_VALUE = 10
+
+export function add(num1, num2) {
+  return num1 + num2
+}
+
+// file.spec.js
+import { MY_VALUE, add } from './file'
+
+add(MY_VALUE, 5)
+// => 15
+```
+
+[mdn-const]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const
+[mdn-export]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export
+[mdn-import]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
+[mdn-let]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let
+[mdn-var]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var
+[wiki-camel-case]: https://en.wikipedia.org/wiki/Camel_case
+[wiki-snake-case]: https://en.wikipedia.org/wiki/Snake_case

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -1,22 +1,30 @@
 # Introduction
 
-TypeScript is a dynamic language, supporting object-oriented, imperative, and declarative (e.g. functional programming) styles.
+TypeScript is JavaScript with syntax for types, making it a a strongly typed programming language, supporting object-oriented, imperative, and declarative (e.g. functional programming) styles, giving you better tooling at any scale.
+
+Because [you cannot learn TypeScript without learning JavaScript][handbook-js-or-ts], some of the content in this Track is focused on teaching JavaScript concepts and some of the concepts focus on TypeScript specific features only.
 
 ## (Re-)Assignment
 
-There are a few primary ways to assign values to names in TypeScript - using variables or constants. On Exercism, variables are always written in [camelCase][wiki-camel-case]; constants are written in [SCREAMING_SNAKE_CASE][wiki-snake-case]. There is no official guide to follow, and various companies and organizations have various style guides. _Feel free to write variables any way you like_. The upside from writing them the way the exercises are prepared is that they'll be highlighted differently in the web interface and most IDEs.
+There are a few primary ways to assign values to names in TypeScript - using variables or constants.
+On Exercism, variables are always written in [camelCase][wiki-camel-case]; constants are written in [SCREAMING_SNAKE_CASE][wiki-snake-case].
+There is no official guide to follow, and various companies and organizations have various style guides.
+_Feel free to write variables any way you like_.
+The upside from writing them the way the exercises are prepared is that they'll be highlighted differently in the web interface and most IDEs.
 
 Variables in TypeScript can be defined using the [`const`][mdn-const], [`let`][mdn-let] or [`var`][mdn-var] keyword.
 
-A variable can reference different values over its lifetime when using `let` or `var`. For example, `myFirstVariable` can be defined and redefined many times using the assignment operator `=`:
+A variable can reference different values over its lifetime when using `let` or `var`.
+For example, `myFirstVariable` can be defined and redefined many times using the assignment operator `=`:
 
 ```typescript
 let myFirstVariable = 1
-myFirstVariable = 'Some string'
-myFirstVariable = new SomeComplexClass()
+myFirstVariable = 0
+myFirstVariable = 42
 ```
 
-In contrast to `let` and `var`, variables that are defined with `const` can only be assigned once. This is used to define constants in TypeScript.
+In contrast to `let` and `var`, variables that are defined with `const` can only be assigned once.
+This is used to define constants in TypeScript.
 
 ```typescript
 const MY_FIRST_CONSTANT = 10
@@ -26,14 +34,51 @@ MY_FIRST_CONSTANT = 20
 // => TypeError: Assignment to constant variable.
 ```
 
+Because TypeScript can detect this statically, the TypeScript compiler will also yield an error:
+
+```typescript
+// ^? Cannot assign to 'MY_FIRST_CONSTANT' because it is a constant.(2588)
+```
+
+This means you don't need to run the code to detect the `TypeError`.
+
 > 💡 In a later Learning Exercise, the difference between _constant_ assignment / binding and _constant_ value is explored and explained.
+
+## Type inference
+
+Without diving too deep into the subject of [type inference][handbook-type-inference], you should be aware that an assigned variable usually as an inferred type, even without a type annotation.
+
+```typescript
+const MY_FIRST_CONSTANT = 10
+// ^? const MY_FIRST_CONSTANT: number
+```
+
+This type is then enforced throughout the code.
+This also means that where the following code is valid JavaScript:
+
+```javascript
+let myFirstVariable = 1
+myFirstVariable = 'Some string'
+```
+
+It complains when using TypeScript:
+
+```typescript
+let myFirstVariable = 1
+myFirstVariable = 'Some string'
+// ^? Type 'string' is not assignable to type 'number'.(2322)
+```
+
+This feature ensures type-safety even when type annotations are not used.
 
 ## Function Declarations
 
-In TypeScript, units of functionality are encapsulated in _functions_, usually grouping functions together in the same file if they belong together. These functions can take parameters (arguments), and can _return_ a value using the `return` keyword. Functions are invoked using `()` syntax.
+In TypeScript, units of functionality are encapsulated in _functions_, usually grouping functions together in the same file if they belong together.
+These functions can take parameters (arguments), and can _return_ a value using the `return` keyword.
+Functions are invoked using `()` syntax.
 
 ```typescript
-function add(num1, num2) {
+function add(num1: number, num2: number): number {
   return num1 + num2
 }
 
@@ -41,22 +86,46 @@ add(1, 3)
 // => 4
 ```
 
-> 💡 In TypeScript there are _many_ different ways to declare a function. These other ways look different than using the `function` keyword. The track tries to gradually introduce them, but if you already know about them, feel free to use any of them. In most cases, using one or the other isn't better or worse.
+Function parameters should usually be annotated with a type using a colon (`:`) followed by the type.
+Function return values can be annotated after closing the parameter list using a colon (`:`) followed by the type.
+
+> 💡 In TypeScript there are _many_ different ways to declare a function.
+> These other ways look different than using the `function` keyword.
+> The track tries to gradually introduce them, but if you already know about them, feel free to use any of them.
+> In most cases, using one or the other isn't better or worse.
+
+## Type Annotations
+
+As shown in the function declaration for `add`, the parameters have an explicit type annotation `: number`.
+Variable declarations, class properties, function declarations and more all support type annotations.
+
+Both explicit type annotation as inferred types are enforced by the type-checker.
+
+```typescript
+add('foo', 3)
+// ^? Argument of type 'string' is not assignable to parameter of type 'number'.(2345)
+```
 
 ## Exposing to Other Files
 
-To make a `function`, a constant, or a variable available in _other files_, they need to be [exported][mdn-export] using the `export` keyword. Another file may then [import][mdn-import] these using the `import` keyword. This is also known as the module system. A great example is how all the tests work. Each exercise has at least one file, for example `lasagna.js`, which contains the _implementation_. Additionally, there is at least one other file, for example `lasagna.spec.js`, that contains the _tests_. This file _imports_ the public (i.e. exported) entities to test the implementation:
+To make a `function`, a constant, or a variable available in _other files_, they need to be [exported][mdn-export] using the `export` keyword.
+Another file may then [import][mdn-import] these using the `import` keyword.
+This is also known as the module system.
+A great example is how all the tests work.
+Each exercise has at least one file, for example `lasagna.ts`, which contains the _implementation_.
+Additionally, there is at least one other file, for example `lasagna.test.ts`, that contains the _tests_.
+This file _imports_ the public (i.e. exported) entities to test the implementation:
 
 ```typescript
-// file.js
+// file.ts
 export const MY_VALUE = 10
 
 export function add(num1, num2) {
   return num1 + num2
 }
 
-// file.spec.js
-import { MY_VALUE, add } from './file'
+// file.test.ts
+import { MY_VALUE, add } from './file.js'
 
 add(MY_VALUE, 5)
 // => 15
@@ -67,5 +136,7 @@ add(MY_VALUE, 5)
 [mdn-import]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 [mdn-let]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let
 [mdn-var]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var
+[handbook-js-or-ts]: https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html#learning-javascript-and-typescript
+[handbook-type-inference]: https://www.typescriptlang.org/docs/handbook/type-inference.html
 [wiki-camel-case]: https://en.wikipedia.org/wiki/Camel_case
 [wiki-snake-case]: https://en.wikipedia.org/wiki/Snake_case

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -42,7 +42,10 @@ Because TypeScript can detect this statically, the TypeScript compiler will also
 
 This means you don't need to run the code to detect the `TypeError`.
 
-> 💡 In a later Learning Exercise, the difference between _constant_ assignment / binding and _constant_ value is explored and explained.
+<!--prettier-ignore -->
+~~~~exercism/note
+💡 In a later Learning Exercise, the difference between _constant_ assignment / binding and _constant_ value is explored and explained.
+~~~~
 
 ## Type inference
 
@@ -89,10 +92,13 @@ add(1, 3)
 Function parameters should usually be annotated with a type using a colon (`:`) followed by the type.
 Function return values can be annotated after closing the parameter list using a colon (`:`) followed by the type.
 
-> 💡 In TypeScript there are _many_ different ways to declare a function.
-> These other ways look different than using the `function` keyword.
-> The track tries to gradually introduce them, but if you already know about them, feel free to use any of them.
-> In most cases, using one or the other isn't better or worse.
+<!--prettier-ignore -->
+~~~~exercism/note
+💡 In TypeScript there are _many_ different ways to declare a function.
+These other ways look different than using the `function` keyword.
+The track tries to gradually introduce them, but if you already know about them, feel free to use any of them.
+In most cases, using one or the other isn't better or worse.
+~~~~
 
 ## Type Annotations
 

--- a/concepts/basics/links.json
+++ b/concepts/basics/links.json
@@ -1,0 +1,34 @@
+[
+  {
+    "url": "https://developer.mozilla.org/en-US/docs/Glossary/Primitive",
+    "description": "MDN Glossary: JavaScript Primitive"
+  },
+  {
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze",
+    "description": "MDN: JavaScript Object freezing"
+  },
+  {
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules",
+    "description": "MDN: JavaScript Module System"
+  },
+  {
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#Renaming_imports_and_exports",
+    "description": "MDN: Renaming modules when importing or exporting"
+  },
+  {
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Imports",
+    "description": "MDN: JavaScript Dynamic imports"
+  },
+  {
+    "url": "https://en.wikipedia.org/wiki/Immutable_object",
+    "description": "About immutable objects"
+  },
+  {
+    "url": "https://bitsofco.de/what-is-tree-shaking/",
+    "description": "About tree shaking"
+  },
+  {
+    "url": "https://2ality.com/2015/07/es6-module-exports.html#es6-modules-export-immutable-bindings",
+    "description": "About live bindings (JavaScript exports)"
+  }
+]

--- a/concepts/basics/links.json
+++ b/concepts/basics/links.json
@@ -1,5 +1,17 @@
 [
   {
+    "url": "https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html",
+    "description": "TypeScript for JavaScript Programmers"
+  },
+  {
+    "url": "https://www.typescriptlang.org/docs/handbook/2/basic-types.html",
+    "description": "TypeScript Handbook: The Basics"
+  },
+  {
+    "url": "https://www.typescriptlang.org/docs/handbook/type-inference.html",
+    "description": "TypeScript Handbook: Type Inference"
+  },
+  {
     "url": "https://developer.mozilla.org/en-US/docs/Glossary/Primitive",
     "description": "MDN Glossary: JavaScript Primitive"
   },

--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
     "highlightjs_language": "typescript"
   },
   "test_runner": {
-    "average_run_time": 4
+    "average_run_time": 8
   },
   "files": {
     "solution": [
@@ -38,8 +38,9 @@
         "slug": "lasagna",
         "name": "lasagna",
         "uuid": "a0bed44f-b179-4d09-8788-a23d2ace359e",
-        "concepts": [],
-        "prerequisites": []
+        "concepts": ["basics"],
+        "prerequisites": [],
+        "status": "beta"
       }
     ],
     "practice": [

--- a/config.json
+++ b/config.json
@@ -40,7 +40,7 @@
         "uuid": "a0bed44f-b179-4d09-8788-a23d2ace359e",
         "concepts": ["basics"],
         "prerequisites": [],
-        "status": "beta"
+        "status": "wip"
       }
     ],
     "practice": [

--- a/config.json
+++ b/config.json
@@ -1459,6 +1459,13 @@
       }
     ]
   },
+  "concepts": [
+    {
+      "uuid": "6b93ea93-3312-4aee-ad6f-3f8b034e92d9",
+      "slug": "basics",
+      "name": "Basics"
+    }
+  ],
   "key_features": [
     {
       "title": "Evolving",

--- a/config.json
+++ b/config.json
@@ -19,12 +19,29 @@
     "average_run_time": 4
   },
   "files": {
-    "solution": ["%{kebab_slug}.ts"],
-    "test": ["%{kebab_slug}.test.ts"],
-    "example": [".meta/proof.ci.ts"],
-    "exemplar": [".meta/exemplar.ts"]
+    "solution": [
+      "%{kebab_slug}.ts"
+    ],
+    "test": [
+      "%{kebab_slug}.test.ts"
+    ],
+    "example": [
+      ".meta/proof.ci.ts"
+    ],
+    "exemplar": [
+      ".meta/exemplar.ts"
+    ]
   },
   "exercises": {
+    "concept": [
+      {
+        "slug": "lasagna",
+        "name": "lasagna",
+        "uuid": "a0bed44f-b179-4d09-8788-a23d2ace359e",
+        "concepts": [],
+        "prerequisites": []
+      }
+    ],
     "practice": [
       {
         "slug": "hello-world",
@@ -33,7 +50,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["optional_values", "strings", "text_formatting"]
+        "topics": [
+          "optional_values",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "two-fer",
@@ -42,7 +63,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["optional_values", "strings", "text_formatting"]
+        "topics": [
+          "optional_values",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "resistor-color",
@@ -51,7 +76,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["arrays", "strings"]
+        "topics": [
+          "arrays",
+          "strings"
+        ]
       },
       {
         "slug": "resistor-color-duo",
@@ -60,7 +88,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["strings", "arrays"]
+        "topics": [
+          "strings",
+          "arrays"
+        ]
       },
       {
         "slug": "resistor-color-trio",
@@ -69,7 +100,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["strings", "arrays"]
+        "topics": [
+          "strings",
+          "arrays"
+        ]
       },
       {
         "slug": "leap",
@@ -78,7 +112,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["booleans", "integers", "logic"]
+        "topics": [
+          "booleans",
+          "integers",
+          "logic"
+        ]
       },
       {
         "slug": "rna-transcription",
@@ -87,7 +125,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["strings", "transforming"]
+        "topics": [
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "space-age",
@@ -96,7 +137,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["classes", "floating_point_numbers"]
+        "topics": [
+          "classes",
+          "floating_point_numbers"
+        ]
       },
       {
         "slug": "dnd-character",
@@ -105,7 +149,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["classes"]
+        "topics": [
+          "classes"
+        ]
       },
       {
         "slug": "darts",
@@ -186,7 +232,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "maps", "sorting"]
+        "topics": [
+          "arrays",
+          "maps",
+          "sorting"
+        ]
       },
       {
         "slug": "clock",
@@ -195,7 +245,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["integers", "logic", "strings"]
+        "topics": [
+          "integers",
+          "logic",
+          "strings"
+        ]
       },
       {
         "slug": "secret-handshake",
@@ -220,7 +274,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "arrays", "conditionals", "loops"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "conditionals",
+          "loops"
+        ]
       },
       {
         "slug": "linked-list",
@@ -246,7 +305,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "floating_point_numbers", "math"]
+        "topics": [
+          "algorithms",
+          "floating_point_numbers",
+          "math"
+        ]
       },
       {
         "slug": "atbash-cipher",
@@ -304,7 +367,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["data_structures", "lists", "recursion"]
+        "topics": [
+          "data_structures",
+          "lists",
+          "recursion"
+        ]
       },
       {
         "slug": "word-count",
@@ -328,7 +395,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["algorithms", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "gigasecond",
@@ -337,7 +409,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["time"]
+        "topics": [
+          "time"
+        ]
       },
       {
         "slug": "reverse-string",
@@ -346,7 +420,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["loops", "strings"]
+        "topics": [
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "triangle",
@@ -355,7 +432,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["conditionals", "loops", "exception_handling", "integers"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "exception_handling",
+          "integers"
+        ]
       },
       {
         "slug": "collatz-conjecture",
@@ -379,7 +461,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["loops", "integers", "maps", "transforming"]
+        "topics": [
+          "loops",
+          "integers",
+          "maps",
+          "transforming"
+        ]
       },
       {
         "slug": "protein-translation",
@@ -388,7 +475,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["arrays", "conditionals", "loops", "strings"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "raindrops",
@@ -397,7 +489,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["conditionals", "integers", "strings", "transforming"]
+        "topics": [
+          "conditionals",
+          "integers",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "hamming",
@@ -406,7 +503,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["conditionals", "loops", "equality", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "equality",
+          "strings"
+        ]
       },
       {
         "slug": "nucleotide-count",
@@ -430,7 +532,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "maps", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "maps",
+          "strings"
+        ]
       },
       {
         "slug": "allergies",
@@ -439,7 +546,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["arrays", "bitwise_operations", "conditionals", "loops"]
+        "topics": [
+          "arrays",
+          "bitwise_operations",
+          "conditionals",
+          "loops"
+        ]
       },
       {
         "slug": "perfect-numbers",
@@ -448,7 +560,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["arrays", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "complex-numbers",
@@ -457,7 +575,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "conditionals", "loops", "math"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "math"
+        ]
       },
       {
         "slug": "luhn",
@@ -466,7 +589,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["conditionals", "loops", "integers", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers",
+          "strings"
+        ]
       },
       {
         "slug": "grains",
@@ -475,7 +603,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "integers"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers"
+        ]
       },
       {
         "slug": "pythagorean-triplet",
@@ -484,7 +616,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "sum-of-multiples",
@@ -493,7 +631,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "integers", "lists", "math"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers",
+          "lists",
+          "math"
+        ]
       },
       {
         "slug": "acronym",
@@ -502,7 +646,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["loops", "regular_expressions", "strings", "transforming"]
+        "topics": [
+          "loops",
+          "regular_expressions",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "anagram",
@@ -511,7 +660,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["filtering", "strings"]
+        "topics": [
+          "filtering",
+          "strings"
+        ]
       },
       {
         "slug": "isogram",
@@ -520,7 +672,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["conditionals", "loops", "filtering", "searching", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "filtering",
+          "searching",
+          "strings"
+        ]
       },
       {
         "slug": "roman-numerals",
@@ -543,7 +701,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["loops", "exception_handling", "strings", "text_formatting"]
+        "topics": [
+          "loops",
+          "exception_handling",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "phone-number",
@@ -552,7 +715,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["parsing", "transforming"]
+        "topics": [
+          "parsing",
+          "transforming"
+        ]
       },
       {
         "slug": "two-bucket",
@@ -613,7 +779,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "text_formatting"]
+        "topics": [
+          "algorithms",
+          "text_formatting"
+        ]
       },
       {
         "slug": "house",
@@ -622,7 +791,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "conditionals", "loops", "recursion", "strings"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "recursion",
+          "strings"
+        ]
       },
       {
         "slug": "isbn-verifier",
@@ -693,7 +868,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "say",
@@ -718,7 +897,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "conditionals", "loops", "matrices", "strings"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "matrices",
+          "strings"
+        ]
       },
       {
         "slug": "saddle-points",
@@ -809,7 +994,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["algorithms", "games"]
+        "topics": [
+          "algorithms",
+          "games"
+        ]
       },
       {
         "slug": "connect",
@@ -851,7 +1039,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "diamond",
@@ -877,7 +1071,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "math"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "math"
+        ]
       },
       {
         "slug": "binary-search-tree",
@@ -886,7 +1084,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["algorithms", "conditionals", "loops", "recursion"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "recursion"
+        ]
       },
       {
         "slug": "sublist",
@@ -961,7 +1164,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "integers", "math", "recursion"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers",
+          "math",
+          "recursion"
+        ]
       },
       {
         "slug": "palindrome-products",
@@ -970,7 +1179,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "diffie-hellman",
@@ -1011,7 +1226,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["algorithms", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "run-length-encoding",
@@ -1037,7 +1256,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["classes", "conditionals"]
+        "topics": [
+          "classes",
+          "conditionals"
+        ]
       },
       {
         "slug": "eliuds-eggs",
@@ -1054,7 +1276,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["strings", "iterators"]
+        "topics": [
+          "strings",
+          "iterators"
+        ]
       },
       {
         "slug": "strain",
@@ -1081,7 +1306,12 @@
         "prerequisites": [],
         "difficulty": 5,
         "status": "deprecated",
-        "topics": ["algorithms", "callbacks", "conditionals", "lists"]
+        "topics": [
+          "algorithms",
+          "callbacks",
+          "conditionals",
+          "lists"
+        ]
       },
       {
         "slug": "all-your-base",
@@ -1106,7 +1336,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["arrays", "lists", "loops", "recursion"]
+        "topics": [
+          "arrays",
+          "lists",
+          "loops",
+          "recursion"
+        ]
       },
       {
         "slug": "matching-brackets",
@@ -1115,14 +1350,23 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["parsing", "stacks", "strings"]
+        "topics": [
+          "parsing",
+          "stacks",
+          "strings"
+        ]
       },
       {
         "slug": "tournament",
         "name": "Tournament",
         "uuid": "f4634d37-2357-4b54-8cd8-ad450234537a",
-        "practices": ["string-formatting"],
-        "prerequisites": ["strings", "string-formatting"],
+        "practices": [
+          "string-formatting"
+        ],
+        "prerequisites": [
+          "strings",
+          "string-formatting"
+        ],
         "difficulty": 6
       },
       {
@@ -1132,7 +1376,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["algorithms", "arrays", "games"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "games"
+        ]
       },
       {
         "slug": "kindergarten-garden",
@@ -1173,7 +1421,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["algorithms", "closures", "reactive_programming"]
+        "topics": [
+          "algorithms",
+          "closures",
+          "reactive_programming"
+        ]
       },
       {
         "slug": "crypto-square",
@@ -1200,7 +1452,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 9,
-        "topics": ["algorithms"]
+        "topics": [
+          "algorithms"
+        ]
       }
     ]
   },

--- a/exercises/concept/lasagna/.docs/hints.md
+++ b/exercises/concept/lasagna/.docs/hints.md
@@ -1,0 +1,30 @@
+# Hints
+
+## 1. Define the expected oven time in minutes
+
+- Define a [constant][constants] which should contain the [`number`][numbers] value specified in the recipe.
+- [`export`][export] the constant.
+
+## 2. Calculate the remaining oven time in minutes
+
+- [Explicitly return a number][return] from the function.
+- Use the [mathematical operator for subtraction][operators] to subtract values.
+
+## 3. Calculate the preparation time in minutes
+
+- [Explicitly return a number][return] from the function.
+- Use the [mathematical operator for multiplication][operators] to multiply values.
+- Use the extra constant for the time in minutes per layer.
+
+## 4. Calculate the total working time in minutes
+
+- [Explicitly return a number][return] from the function.
+- [Invoke][invocation] one of the other methods implemented previously.
+- Use the [mathematical operator for addition][operators] to add values.
+
+[return]: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Return_values
+[export]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export
+[operators]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators
+[constants]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const
+[invocation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions#Calling_functions
+[numbers]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type

--- a/exercises/concept/lasagna/.docs/instructions.md
+++ b/exercises/concept/lasagna/.docs/instructions.md
@@ -1,0 +1,38 @@
+# Instructions
+
+Lucian's girlfriend is on her way home, and he hasn't cooked their anniversary dinner!
+
+In this exercise, you're going to write some code to help Lucian cook an exquisite lasagna from his favorite cookbook.
+
+You have four tasks related to the time spent cooking the lasagna.
+
+## 1. Define the expected oven time in minutes
+
+Define the `EXPECTED_MINUTES_IN_OVEN` constant that represents how many minutes the lasagna should be in the oven. It must be exported. According to the cooking book, the expected oven time in minutes is `40`.
+
+## 2. Calculate the remaining oven time in minutes
+
+Implement the `remainingMinutesInOven` function that takes the actual minutes the lasagna has been in the oven as a _parameter_ and _returns_ how many minutes the lasagna still has to remain in the oven, based on the **expected oven time in minutes** from the previous task.
+
+```javascript
+remainingMinutesInOven(30);
+// => 10
+```
+
+## 3. Calculate the preparation time in minutes
+
+Implement the `preparationTimeInMinutes` function that takes the number of layers you added to the lasagna as a _parameter_ and _returns_ how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
+
+```javascript
+preparationTimeInMinutes(2);
+// => 4
+```
+
+## 4. Calculate the total working time in minutes
+
+Implement the `totalTimeInMinutes` function that takes _two parameters_: the `numberOfLayers` parameter is the number of layers you added to the lasagna, and the `actualMinutesInOven` parameter is the number of minutes the lasagna has been in the oven. The function should _return_ how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
+
+```javascript
+totalTimeInMinutes(3, 20);
+// => 26
+```

--- a/exercises/concept/lasagna/.docs/instructions.md
+++ b/exercises/concept/lasagna/.docs/instructions.md
@@ -15,7 +15,7 @@ Define the `EXPECTED_MINUTES_IN_OVEN` constant that represents how many minutes 
 Implement the `remainingMinutesInOven` function that takes the actual minutes the lasagna has been in the oven as a _parameter_ and _returns_ how many minutes the lasagna still has to remain in the oven, based on the **expected oven time in minutes** from the previous task.
 
 ```javascript
-remainingMinutesInOven(30);
+remainingMinutesInOven(30)
 // => 10
 ```
 
@@ -24,7 +24,7 @@ remainingMinutesInOven(30);
 Implement the `preparationTimeInMinutes` function that takes the number of layers you added to the lasagna as a _parameter_ and _returns_ how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
 
 ```javascript
-preparationTimeInMinutes(2);
+preparationTimeInMinutes(2)
 // => 4
 ```
 
@@ -33,6 +33,6 @@ preparationTimeInMinutes(2);
 Implement the `totalTimeInMinutes` function that takes _two parameters_: the `numberOfLayers` parameter is the number of layers you added to the lasagna, and the `actualMinutesInOven` parameter is the number of minutes the lasagna has been in the oven. The function should _return_ how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
 
 ```javascript
-totalTimeInMinutes(3, 20);
+totalTimeInMinutes(3, 20)
 // => 26
 ```

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -1,0 +1,71 @@
+# Introduction
+
+JavaScript is a dynamic language, supporting object-oriented, imperative, and declarative (e.g. functional programming) styles.
+
+## (Re-)Assignment
+
+There are a few primary ways to assign values to names in JavaScript - using variables or constants. On Exercism, variables are always written in [camelCase][wiki-camel-case]; constants are written in [SCREAMING_SNAKE_CASE][wiki-snake-case]. There is no official guide to follow, and various companies and organizations have various style guides. _Feel free to write variables any way you like_. The upside from writing them the way the exercises are prepared is that they'll be highlighted differently in the web interface and most IDEs.
+
+Variables in JavaScript can be defined using the [`const`][mdn-const], [`let`][mdn-let] or [`var`][mdn-var] keyword.
+
+A variable can reference different values over its lifetime when using `let` or `var`. For example, `myFirstVariable` can be defined and redefined many times using the assignment operator `=`:
+
+```javascript
+let myFirstVariable = 1;
+myFirstVariable = 'Some string';
+myFirstVariable = new SomeComplexClass();
+```
+
+In contrast to `let` and `var`, variables that are defined with `const` can only be assigned once. This is used to define constants in JavaScript.
+
+```javascript
+const MY_FIRST_CONSTANT = 10;
+
+// Can not be re-assigned.
+MY_FIRST_CONSTANT = 20;
+// => TypeError: Assignment to constant variable.
+```
+
+> 💡 In a later Concept Exercise the difference between _constant_ assignment / binding and _constant_ value is explored and explained.
+
+## Function Declarations
+
+In JavaScript, units of functionality are encapsulated in _functions_, usually grouping functions together in the same file if they belong together. These functions can take parameters (arguments), and can _return_ a value using the `return` keyword. Functions are invoked using `()` syntax.
+
+```javascript
+function add(num1, num2) {
+  return num1 + num2;
+}
+
+add(1, 3);
+// => 4
+```
+
+> 💡 In JavaScript there are _many_ different ways to declare a function. These other ways look different than using the `function` keyword. The track tries to gradually introduce them, but if you already know about them, feel free to use any of them. In most cases, using one or the other isn't better or worse.
+
+## Exposing to Other Files
+
+To make a `function`, a constant, or a variable available in _other files_, they need to be [exported][mdn-export] using the `export` keyword. Another file may then [import][mdn-import] these using the `import` keyword. This is also known as the module system. A great example is how all the tests work. Each exercise has at least one file, for example `lasagna.js`, which contains the _implementation_. Additionally there is at least one other file, for example `lasagna.spec.js`, that contains the _tests_. This file _imports_ the public (i.e. exported) entities in order to test the implementation:
+
+```javascript
+// file.js
+export const MY_VALUE = 10;
+
+export function add(num1, num2) {
+  return num1 + num2;
+}
+
+// file.spec.js
+import { MY_VALUE, add } from './file';
+
+add(MY_VALUE, 5);
+// => 15
+```
+
+[mdn-const]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const
+[mdn-export]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export
+[mdn-import]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
+[mdn-let]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let
+[mdn-var]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var
+[wiki-camel-case]: https://en.wikipedia.org/wiki/Camel_case
+[wiki-snake-case]: https://en.wikipedia.org/wiki/Snake_case

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -11,18 +11,18 @@ Variables in JavaScript can be defined using the [`const`][mdn-const], [`let`][m
 A variable can reference different values over its lifetime when using `let` or `var`. For example, `myFirstVariable` can be defined and redefined many times using the assignment operator `=`:
 
 ```javascript
-let myFirstVariable = 1;
-myFirstVariable = 'Some string';
-myFirstVariable = new SomeComplexClass();
+let myFirstVariable = 1
+myFirstVariable = 'Some string'
+myFirstVariable = new SomeComplexClass()
 ```
 
 In contrast to `let` and `var`, variables that are defined with `const` can only be assigned once. This is used to define constants in JavaScript.
 
 ```javascript
-const MY_FIRST_CONSTANT = 10;
+const MY_FIRST_CONSTANT = 10
 
 // Can not be re-assigned.
-MY_FIRST_CONSTANT = 20;
+MY_FIRST_CONSTANT = 20
 // => TypeError: Assignment to constant variable.
 ```
 
@@ -34,10 +34,10 @@ In JavaScript, units of functionality are encapsulated in _functions_, usually g
 
 ```javascript
 function add(num1, num2) {
-  return num1 + num2;
+  return num1 + num2
 }
 
-add(1, 3);
+add(1, 3)
 // => 4
 ```
 
@@ -49,16 +49,16 @@ To make a `function`, a constant, or a variable available in _other files_, they
 
 ```javascript
 // file.js
-export const MY_VALUE = 10;
+export const MY_VALUE = 10
 
 export function add(num1, num2) {
-  return num1 + num2;
+  return num1 + num2
 }
 
 // file.spec.js
-import { MY_VALUE, add } from './file';
+import { MY_VALUE, add } from './file'
 
-add(MY_VALUE, 5);
+add(MY_VALUE, 5)
 // => 15
 ```
 

--- a/exercises/concept/lasagna/.meta/config.json
+++ b/exercises/concept/lasagna/.meta/config.json
@@ -1,0 +1,27 @@
+{
+  "authors": ["SleeplessByte"],
+  "files": {
+    "solution": [
+      "lasagna.ts"
+    ],
+    "test": [
+      "__typetests__/lasagna.tst.ts",
+      "lasagna.test.ts"
+    ],
+    "exemplar": [
+      ".meta/exemplar.ts"
+    ]
+  },
+  "forked_from": [
+    "javascript/lasagna"
+  ],
+  "blurb": "Learn the basics of TypeScript cooking a brilliant lasagna from your favorite cooking book.",
+  "custom": {
+    "version.tests.compatibility": "jest-29",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false,
+    "flag.tests.jest": true,
+    "flag.tests.tstyche": true
+  }
+}

--- a/exercises/concept/lasagna/.meta/design.md
+++ b/exercises/concept/lasagna/.meta/design.md
@@ -1,0 +1,38 @@
+# Design
+
+## Learning objectives
+
+- Know what a variable is.
+- Know what a constant variable is.
+- Know how to define a variable.
+- Know how to export a variable
+- Know how to return a value from a function (explicit return).
+- Know how to annotate a function parameter
+- Know how to annotate a function return type
+
+## Out of scope
+
+This exercise is really just to introduce the bare minimum a student needs to know to solve a very basic exercise on Exercism.
+Details about the primitive data types, different ways to define functions etc. will all be properly introduced in the later concept exercises.
+
+We don't even explicitly teach the basics of numbers and arithmetic operators in the introduction.
+Given the general code examples that are provided and some "I will just try that", the student should be fine solving the exercise nevertheless.
+
+## Concepts
+
+- `basics`
+
+## Prerequisites
+
+There are no prerequisites.
+
+## Analyzer
+
+This exercise could benefit from the following rules added to the the [analyzer][analyzer]:
+
+- Verify that the `remainingMinutesInOven` function uses the `EXPECTED_MINUTES_IN_OVEN` constant.
+- Verify that the `preparationTimeInMinutes` function uses the `PREPARATION_MINUTES_PER_LAYER` constant.
+- Verify that the `totalTimeInMinutes` function calls the `preparationTimeInMinutes` function.
+- Verify that no extra _bookkeeping_ or _intermediate_ variables are declared
+
+[analyzer]: https://github.com/exercism/typescript-analyzer

--- a/exercises/concept/lasagna/.meta/exemplar.ts
+++ b/exercises/concept/lasagna/.meta/exemplar.ts
@@ -1,0 +1,45 @@
+/**
+ * The amount of minutes the lasagna should be in the oven.
+ */
+export const EXPECTED_MINUTES_IN_OVEN = 40
+
+/**
+ * The amount of minutes it takes to prepare a single layer.
+ */
+const PREPARATION_MINUTES_PER_LAYER = 2
+
+/**
+ * Determines the amount of minutes the lasagna still needs to remain in the
+ * oven to be properly prepared.
+ *
+ * @param actualMinutesInOven
+ * @returns the number of minutes remaining
+ */
+export function remainingMinutesInOven(actualMinutesInOven: number): number {
+  return EXPECTED_MINUTES_IN_OVEN - actualMinutesInOven
+}
+
+/**
+ * Given a number of layers, determines the total preparation time.
+ *
+ * @param numberOfLayers
+ * @returns the total preparation time
+ */
+export function preparationTimeInMinutes(numberOfLayers: number): number {
+  return numberOfLayers * PREPARATION_MINUTES_PER_LAYER
+}
+
+/**
+ * Calculates the total working time. That is, the time to prepare all the layers
+ * of lasagna, and the time already spent in the oven.
+ *
+ * @param numberOfLayers
+ * @param actualMinutesInOven
+ * @returns the total working time
+ */
+export function totalTimeInMinutes(
+  numberOfLayers: number,
+  actualMinutesInOven: number
+): number {
+  return preparationTimeInMinutes(numberOfLayers) + actualMinutesInOven
+}

--- a/exercises/concept/lasagna/.meta/test-runner.mjs
+++ b/exercises/concept/lasagna/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/concept/lasagna/.vscode/extensions.json
+++ b/exercises/concept/lasagna/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "arcanis.vscode-zipfs",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
+  ]
+}

--- a/exercises/concept/lasagna/.vscode/settings.json
+++ b/exercises/concept/lasagna/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "cSpell.words": ["exercism"],
+  "search.exclude": {
+    "**/.yarn": true,
+    "**/.pnp.*": true
+  }
+}

--- a/exercises/concept/lasagna/.yarnrc.yml
+++ b/exercises/concept/lasagna/.yarnrc.yml
@@ -1,0 +1,3 @@
+compressionLevel: mixed
+
+enableGlobalCache: true

--- a/exercises/concept/lasagna/__typetests__/lasagna.tst.ts
+++ b/exercises/concept/lasagna/__typetests__/lasagna.tst.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'tstyche'
+import {
+  EXPECTED_MINUTES_IN_OVEN,
+  remainingMinutesInOven,
+  preparationTimeInMinutes,
+  totalTimeInMinutes,
+} from '../lasagna.ts'
+
+describe('EXPECTED_MINUTES_IN_OVEN', () => {
+  test('constant is defined as a number or a constant number', () => {
+    expect(EXPECTED_MINUTES_IN_OVEN).type.toBeAssignableTo<number>()
+  })
+})
+
+describe('remainingMinutesInOven', () => {
+  test('takes one number parameter', () => {
+    expect<Parameters<typeof remainingMinutesInOven>>().type.toBe<[number]>()
+  })
+
+  test('returns a number', () => {
+    expect<ReturnType<typeof remainingMinutesInOven>>().type.toBe<number>()
+  })
+})
+
+describe('preparationTimeInMinutes', () => {
+  test('takes one number parameter', () => {
+    expect<Parameters<typeof preparationTimeInMinutes>>().type.toBe<[number]>()
+  })
+
+  test('returns a number', () => {
+    expect<ReturnType<typeof preparationTimeInMinutes>>().type.toBe<number>()
+  })
+})
+
+describe('totalTimeInMinutes', () => {
+  test('takes two number parameters', () => {
+    expect<Parameters<typeof totalTimeInMinutes>>().type.toBe<
+      [number, number]
+    >()
+  })
+
+  test('returns a number', () => {
+    expect<ReturnType<typeof totalTimeInMinutes>>().type.toBe<number>()
+  })
+})

--- a/exercises/concept/lasagna/babel.config.cjs
+++ b/exercises/concept/lasagna/babel.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: [[require('@exercism/babel-preset-typescript'), { corejs: '3.37' }]],
+  plugins: [],
+}

--- a/exercises/concept/lasagna/eslint.config.mjs
+++ b/exercises/concept/lasagna/eslint.config.mjs
@@ -1,0 +1,26 @@
+// @ts-check
+
+import tsEslint from 'typescript-eslint'
+import config from '@exercism/eslint-config-typescript'
+import maintainersConfig from '@exercism/eslint-config-typescript/maintainers.mjs'
+
+export default [
+  ...tsEslint.config(...config, {
+    files: ['.meta/proof.ci.ts', '.meta/exemplar.ts', '*.test.ts'],
+    extends: maintainersConfig,
+  }),
+  {
+    ignores: [
+      // # Protected or generated
+      '.git/**/*',
+      '.vscode/**/*',
+
+      //# When using npm
+      'node_modules/**/*',
+
+      // # Configuration files
+      'babel.config.cjs',
+      'jest.config.cjs',
+    ],
+  },
+]

--- a/exercises/concept/lasagna/jest.config.cjs
+++ b/exercises/concept/lasagna/jest.config.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  verbose: true,
+  projects: ['<rootDir>'],
+  testMatch: [
+    '**/__tests__/**/*.[jt]s?(x)',
+    '**/test/**/*.[jt]s?(x)',
+    '**/?(*.)+(spec|test).[jt]s?(x)',
+  ],
+  testPathIgnorePatterns: [
+    '/(?:production_)?node_modules/',
+    '.d.ts$',
+    '<rootDir>/test/fixtures',
+    '<rootDir>/test/helpers',
+    '__mocks__',
+  ],
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest',
+  },
+  moduleNameMapper: {
+    '^(\\.\\/.+)\\.js$': '$1',
+  },
+}

--- a/exercises/concept/lasagna/lasagna.test.ts
+++ b/exercises/concept/lasagna/lasagna.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from '@jest/globals'
+
+import {
+  EXPECTED_MINUTES_IN_OVEN,
+  remainingMinutesInOven,
+  preparationTimeInMinutes,
+  totalTimeInMinutes,
+} from './lasagna.ts'
+
+describe('EXPECTED_MINUTES_IN_OVEN', () => {
+  test('constant is defined correctly', () => {
+    expect(EXPECTED_MINUTES_IN_OVEN).toBe(40)
+  })
+})
+
+describe('remainingMinutesInOven', () => {
+  test('calculates the remaining time', () => {
+    expect(remainingMinutesInOven(25)).toBe(15)
+    expect(remainingMinutesInOven(5)).toBe(35)
+    expect(remainingMinutesInOven(39)).toBe(1)
+  })
+
+  test('works correctly for the edge cases', () => {
+    expect(remainingMinutesInOven(40)).toBe(0)
+    expect(remainingMinutesInOven(0)).toBe(40)
+  })
+})
+
+describe('preparationTimeInMinutes', () => {
+  test('calculates the preparation time', () => {
+    expect(preparationTimeInMinutes(1)).toBe(2)
+    expect(preparationTimeInMinutes(2)).toBe(4)
+    expect(preparationTimeInMinutes(8)).toBe(16)
+  })
+})
+
+describe('totalTimeInMinutes', () => {
+  test('calculates the total cooking time', () => {
+    expect(totalTimeInMinutes(1, 5)).toBe(7)
+    expect(totalTimeInMinutes(4, 15)).toBe(23)
+    expect(totalTimeInMinutes(1, 30)).toBe(32)
+  })
+})

--- a/exercises/concept/lasagna/lasagna.ts
+++ b/exercises/concept/lasagna/lasagna.ts
@@ -1,0 +1,64 @@
+// 👋🏽 Hi there!
+//
+// On the TypeScript track we provide you with stubs. These stubs provide a
+// starting point to solving the exercise.
+//
+// In general, each variable/constant and each declared function will have a
+// JSDoc comment block above it, explaining what the variable/constant holds or
+// the function is supposed to accomplish.
+//
+// 💡 Often, the JSDoc comment blocks have annotations, such as @param and
+// @returns which are usually highlighted with a different color if the IDE
+// you're in recognizes them. It's these annotations that are used when
+// referring to the constant, variable, or function from somewhere else that
+// IDEs display.
+//
+// You don't need to write these yourself; it is not expected in idiomatic
+// TypeScript, but some companies and style-guides do enforce them.
+//
+// 💡 You're allowed to completely clear a stub before you get started. Often
+// we recommend using the stub, because they are already set-up correctly to
+// work with the tests, which you can find in ./lasagna.spec.js
+//
+// Good luck preparing some lasagna!
+
+/**
+ * The number of minutes it takes to prepare a single layer.
+ */
+const PREPARATION_MINUTES_PER_LAYER = 2
+
+/**
+ * Determines the number of minutes the lasagna still needs to remain in the
+ * oven to be properly prepared.
+ *
+ * @param actualMinutesInOven
+ * @returns the number of minutes remaining
+ */
+export function remainingMinutesInOven(actualMinutesInOven: number): number {
+  throw new Error('Remove this line and implement the function')
+}
+
+/**
+ * Given a number of layers, determines the total preparation time.
+ *
+ * @param numberOfLayers
+ * @returns the total preparation time
+ */
+export function preparationTimeInMinutes(numberOfLayers: number): number {
+  throw new Error('Remove this line and implement the function')
+}
+
+/**
+ * Calculates the total working time. That is, the time to prepare all the
+ * layers of lasagna, and the time already spent in the oven.
+ *
+ * @param numberOfLayers
+ * @param actualMinutesInOven
+ * @returns the total working time
+ */
+export function totalTimeInMinutes(
+  numberOfLayers: number,
+  actualMinutesInOven: number
+): number {
+  throw new Error('Remove this line and implement the function')
+}

--- a/exercises/concept/lasagna/package.json
+++ b/exercises/concept/lasagna/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@exercism/typescript-concept-lasagna",
+  "version": "1.0.0",
+  "description": "Exercism concept exercise on lasagna",
+  "author": "Katrina Owen",
+  "contributors": [
+    "Derk-Jan Karrenbeld <derk-jan+git@karrenbeld.info> (https://derk-jan.com)"
+  ],
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/exercism/typescript"
+  },
+  "type": "module",
+  "engines": {
+    "node": "^18.16.0 || >=20.0.0"
+  },
+  "devDependencies": {
+    "@exercism/babel-preset-typescript": "^0.5.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
+    "@jest/globals": "^29.7.0",
+    "@types/node": "~22.0.2",
+    "babel-jest": "^29.7.0",
+    "core-js": "~3.37.1",
+    "eslint": "^9.8.0",
+    "expect": "^29.7.0",
+    "jest": "^29.7.0",
+    "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
+    "typescript": "~5.5.4",
+    "typescript-eslint": "^7.18.0"
+  },
+  "scripts": {
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
+    "lint": "corepack yarn lint:types && corepack yarn lint:ci",
+    "lint:types": "corepack yarn tsc --noEmit -p .",
+    "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"
+  },
+  "packageManager": "yarn@4.3.1"
+}

--- a/exercises/concept/lasagna/package.json
+++ b/exercises/concept/lasagna/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@exercism/typescript-concept-lasagna",
+  "name": "@exercism/typescript-lasagna",
   "version": "1.0.0",
   "description": "Exercism concept exercise on lasagna",
   "author": "Derk-Jan Karrenbeld <derk-jan+git@karrenbeld.info> (https://derk-jan.com)",

--- a/exercises/concept/lasagna/package.json
+++ b/exercises/concept/lasagna/package.json
@@ -2,10 +2,7 @@
   "name": "@exercism/typescript-concept-lasagna",
   "version": "1.0.0",
   "description": "Exercism concept exercise on lasagna",
-  "author": "Katrina Owen",
-  "contributors": [
-    "Derk-Jan Karrenbeld <derk-jan+git@karrenbeld.info> (https://derk-jan.com)"
-  ],
+  "author": "Derk-Jan Karrenbeld <derk-jan+git@karrenbeld.info> (https://derk-jan.com)",
   "private": true,
   "repository": {
     "type": "git",

--- a/exercises/concept/lasagna/tsconfig.json
+++ b/exercises/concept/lasagna/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "display": "Configuration for Exercism TypeScript Exercises",
+  "compilerOptions": {
+    // Allows you to use the newest syntax, and have access to console.log
+    // https://www.typescriptlang.org/tsconfig#lib
+    "lib": ["ES2020", "dom"],
+    // Make sure typescript is configured to output ESM
+    // https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#how-can-i-make-my-typescript-project-output-esm
+    "module": "Node16",
+    // Since this project is using babel, TypeScript may target something very
+    // high, and babel will make sure it runs on your local Node version.
+    // https://babeljs.io/docs/en/
+    "target": "ES2020", // ESLint doesn't support this yet: "es2022",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+
+    // Because jest-resolve isn't like node resolve, the absolute path must be .ts
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+
+    // Because we'll be using babel: ensure that Babel can safely transpile
+    // files in the TypeScript project.
+    //
+    // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
+    "isolatedModules": true
+  },
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/exercises/practice/accumulate/.meta/test-runner.mjs
+++ b/exercises/practice/accumulate/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/accumulate/package.json
+++ b/exercises/practice/accumulate/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/accumulate/package.json
+++ b/exercises/practice/accumulate/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/accumulate/tsconfig.json
+++ b/exercises/practice/accumulate/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/acronym/.meta/test-runner.mjs
+++ b/exercises/practice/acronym/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/acronym/package.json
+++ b/exercises/practice/acronym/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/acronym/package.json
+++ b/exercises/practice/acronym/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/acronym/tsconfig.json
+++ b/exercises/practice/acronym/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/all-your-base/.meta/test-runner.mjs
+++ b/exercises/practice/all-your-base/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/all-your-base/package.json
+++ b/exercises/practice/all-your-base/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/all-your-base/package.json
+++ b/exercises/practice/all-your-base/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/all-your-base/tsconfig.json
+++ b/exercises/practice/all-your-base/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/allergies/.meta/test-runner.mjs
+++ b/exercises/practice/allergies/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/allergies/package.json
+++ b/exercises/practice/allergies/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/allergies/package.json
+++ b/exercises/practice/allergies/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/allergies/tsconfig.json
+++ b/exercises/practice/allergies/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/alphametics/.meta/test-runner.mjs
+++ b/exercises/practice/alphametics/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/alphametics/package.json
+++ b/exercises/practice/alphametics/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/alphametics/package.json
+++ b/exercises/practice/alphametics/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/alphametics/tsconfig.json
+++ b/exercises/practice/alphametics/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/anagram/.meta/test-runner.mjs
+++ b/exercises/practice/anagram/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/anagram/package.json
+++ b/exercises/practice/anagram/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/anagram/package.json
+++ b/exercises/practice/anagram/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/anagram/tsconfig.json
+++ b/exercises/practice/anagram/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/armstrong-numbers/.meta/test-runner.mjs
+++ b/exercises/practice/armstrong-numbers/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/armstrong-numbers/package.json
+++ b/exercises/practice/armstrong-numbers/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/armstrong-numbers/package.json
+++ b/exercises/practice/armstrong-numbers/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/armstrong-numbers/tsconfig.json
+++ b/exercises/practice/armstrong-numbers/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/atbash-cipher/.meta/test-runner.mjs
+++ b/exercises/practice/atbash-cipher/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/atbash-cipher/package.json
+++ b/exercises/practice/atbash-cipher/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/atbash-cipher/package.json
+++ b/exercises/practice/atbash-cipher/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/atbash-cipher/tsconfig.json
+++ b/exercises/practice/atbash-cipher/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/bank-account/.meta/test-runner.mjs
+++ b/exercises/practice/bank-account/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/bank-account/package.json
+++ b/exercises/practice/bank-account/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/bank-account/package.json
+++ b/exercises/practice/bank-account/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/bank-account/tsconfig.json
+++ b/exercises/practice/bank-account/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/beer-song/.meta/test-runner.mjs
+++ b/exercises/practice/beer-song/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/beer-song/package.json
+++ b/exercises/practice/beer-song/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/beer-song/package.json
+++ b/exercises/practice/beer-song/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/beer-song/tsconfig.json
+++ b/exercises/practice/beer-song/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/binary-search-tree/.meta/test-runner.mjs
+++ b/exercises/practice/binary-search-tree/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/binary-search-tree/package.json
+++ b/exercises/practice/binary-search-tree/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/binary-search-tree/package.json
+++ b/exercises/practice/binary-search-tree/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/binary-search-tree/tsconfig.json
+++ b/exercises/practice/binary-search-tree/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/binary-search/.meta/test-runner.mjs
+++ b/exercises/practice/binary-search/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/binary-search/package.json
+++ b/exercises/practice/binary-search/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/binary-search/package.json
+++ b/exercises/practice/binary-search/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/binary-search/tsconfig.json
+++ b/exercises/practice/binary-search/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/bob/.meta/test-runner.mjs
+++ b/exercises/practice/bob/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/bob/package.json
+++ b/exercises/practice/bob/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/bob/package.json
+++ b/exercises/practice/bob/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/bob/tsconfig.json
+++ b/exercises/practice/bob/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/bowling/.meta/test-runner.mjs
+++ b/exercises/practice/bowling/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/bowling/package.json
+++ b/exercises/practice/bowling/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/bowling/package.json
+++ b/exercises/practice/bowling/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/bowling/tsconfig.json
+++ b/exercises/practice/bowling/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/circular-buffer/.meta/test-runner.mjs
+++ b/exercises/practice/circular-buffer/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/circular-buffer/package.json
+++ b/exercises/practice/circular-buffer/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/circular-buffer/package.json
+++ b/exercises/practice/circular-buffer/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/circular-buffer/tsconfig.json
+++ b/exercises/practice/circular-buffer/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/clock/.meta/test-runner.mjs
+++ b/exercises/practice/clock/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/clock/package.json
+++ b/exercises/practice/clock/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/clock/package.json
+++ b/exercises/practice/clock/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/clock/tsconfig.json
+++ b/exercises/practice/clock/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/collatz-conjecture/.meta/test-runner.mjs
+++ b/exercises/practice/collatz-conjecture/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/collatz-conjecture/package.json
+++ b/exercises/practice/collatz-conjecture/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/collatz-conjecture/package.json
+++ b/exercises/practice/collatz-conjecture/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/collatz-conjecture/tsconfig.json
+++ b/exercises/practice/collatz-conjecture/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/complex-numbers/.meta/test-runner.mjs
+++ b/exercises/practice/complex-numbers/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/complex-numbers/package.json
+++ b/exercises/practice/complex-numbers/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/complex-numbers/package.json
+++ b/exercises/practice/complex-numbers/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/complex-numbers/tsconfig.json
+++ b/exercises/practice/complex-numbers/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/connect/.meta/test-runner.mjs
+++ b/exercises/practice/connect/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/connect/package.json
+++ b/exercises/practice/connect/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/connect/package.json
+++ b/exercises/practice/connect/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/connect/tsconfig.json
+++ b/exercises/practice/connect/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/crypto-square/.meta/test-runner.mjs
+++ b/exercises/practice/crypto-square/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/crypto-square/package.json
+++ b/exercises/practice/crypto-square/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/crypto-square/package.json
+++ b/exercises/practice/crypto-square/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/crypto-square/tsconfig.json
+++ b/exercises/practice/crypto-square/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/custom-set/.meta/test-runner.mjs
+++ b/exercises/practice/custom-set/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/custom-set/package.json
+++ b/exercises/practice/custom-set/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/custom-set/package.json
+++ b/exercises/practice/custom-set/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/custom-set/tsconfig.json
+++ b/exercises/practice/custom-set/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/darts/.meta/test-runner.mjs
+++ b/exercises/practice/darts/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/darts/package.json
+++ b/exercises/practice/darts/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/darts/package.json
+++ b/exercises/practice/darts/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/darts/tsconfig.json
+++ b/exercises/practice/darts/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/diamond/.meta/test-runner.mjs
+++ b/exercises/practice/diamond/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/diamond/package.json
+++ b/exercises/practice/diamond/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/diamond/package.json
+++ b/exercises/practice/diamond/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/diamond/tsconfig.json
+++ b/exercises/practice/diamond/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/difference-of-squares/.meta/test-runner.mjs
+++ b/exercises/practice/difference-of-squares/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/difference-of-squares/package.json
+++ b/exercises/practice/difference-of-squares/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/difference-of-squares/package.json
+++ b/exercises/practice/difference-of-squares/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/difference-of-squares/tsconfig.json
+++ b/exercises/practice/difference-of-squares/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/diffie-hellman/.meta/test-runner.mjs
+++ b/exercises/practice/diffie-hellman/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/diffie-hellman/package.json
+++ b/exercises/practice/diffie-hellman/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/diffie-hellman/package.json
+++ b/exercises/practice/diffie-hellman/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/diffie-hellman/tsconfig.json
+++ b/exercises/practice/diffie-hellman/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/dnd-character/.meta/test-runner.mjs
+++ b/exercises/practice/dnd-character/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/dnd-character/package.json
+++ b/exercises/practice/dnd-character/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/dnd-character/package.json
+++ b/exercises/practice/dnd-character/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/dnd-character/tsconfig.json
+++ b/exercises/practice/dnd-character/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/eliuds-eggs/.meta/test-runner.mjs
+++ b/exercises/practice/eliuds-eggs/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/eliuds-eggs/package.json
+++ b/exercises/practice/eliuds-eggs/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/eliuds-eggs/package.json
+++ b/exercises/practice/eliuds-eggs/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/eliuds-eggs/tsconfig.json
+++ b/exercises/practice/eliuds-eggs/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/etl/.meta/test-runner.mjs
+++ b/exercises/practice/etl/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/etl/package.json
+++ b/exercises/practice/etl/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/etl/package.json
+++ b/exercises/practice/etl/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/etl/tsconfig.json
+++ b/exercises/practice/etl/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/flatten-array/.meta/test-runner.mjs
+++ b/exercises/practice/flatten-array/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/flatten-array/package.json
+++ b/exercises/practice/flatten-array/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/flatten-array/package.json
+++ b/exercises/practice/flatten-array/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/flatten-array/tsconfig.json
+++ b/exercises/practice/flatten-array/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/food-chain/.meta/test-runner.mjs
+++ b/exercises/practice/food-chain/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/food-chain/package.json
+++ b/exercises/practice/food-chain/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/food-chain/package.json
+++ b/exercises/practice/food-chain/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/food-chain/tsconfig.json
+++ b/exercises/practice/food-chain/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/gigasecond/.meta/test-runner.mjs
+++ b/exercises/practice/gigasecond/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/gigasecond/package.json
+++ b/exercises/practice/gigasecond/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/gigasecond/package.json
+++ b/exercises/practice/gigasecond/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/gigasecond/tsconfig.json
+++ b/exercises/practice/gigasecond/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/grade-school/.meta/test-runner.mjs
+++ b/exercises/practice/grade-school/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/grade-school/package.json
+++ b/exercises/practice/grade-school/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/grade-school/package.json
+++ b/exercises/practice/grade-school/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/grade-school/tsconfig.json
+++ b/exercises/practice/grade-school/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/grains/.meta/test-runner.mjs
+++ b/exercises/practice/grains/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/grains/package.json
+++ b/exercises/practice/grains/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/grains/package.json
+++ b/exercises/practice/grains/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/grains/tsconfig.json
+++ b/exercises/practice/grains/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/hamming/.meta/test-runner.mjs
+++ b/exercises/practice/hamming/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/hamming/package.json
+++ b/exercises/practice/hamming/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/hamming/package.json
+++ b/exercises/practice/hamming/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/hamming/tsconfig.json
+++ b/exercises/practice/hamming/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/hello-world/.meta/test-runner.mjs
+++ b/exercises/practice/hello-world/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/hello-world/package.json
+++ b/exercises/practice/hello-world/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/hello-world/package.json
+++ b/exercises/practice/hello-world/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/hello-world/tsconfig.json
+++ b/exercises/practice/hello-world/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/house/.meta/test-runner.mjs
+++ b/exercises/practice/house/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/house/package.json
+++ b/exercises/practice/house/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/house/package.json
+++ b/exercises/practice/house/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/house/tsconfig.json
+++ b/exercises/practice/house/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/isbn-verifier/.meta/test-runner.mjs
+++ b/exercises/practice/isbn-verifier/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/isbn-verifier/package.json
+++ b/exercises/practice/isbn-verifier/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/isbn-verifier/package.json
+++ b/exercises/practice/isbn-verifier/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/isbn-verifier/tsconfig.json
+++ b/exercises/practice/isbn-verifier/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/isogram/.meta/test-runner.mjs
+++ b/exercises/practice/isogram/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/isogram/package.json
+++ b/exercises/practice/isogram/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/isogram/package.json
+++ b/exercises/practice/isogram/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/isogram/tsconfig.json
+++ b/exercises/practice/isogram/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/kindergarten-garden/.meta/test-runner.mjs
+++ b/exercises/practice/kindergarten-garden/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/kindergarten-garden/package.json
+++ b/exercises/practice/kindergarten-garden/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/kindergarten-garden/package.json
+++ b/exercises/practice/kindergarten-garden/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/kindergarten-garden/tsconfig.json
+++ b/exercises/practice/kindergarten-garden/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/knapsack/.meta/test-runner.mjs
+++ b/exercises/practice/knapsack/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/knapsack/package.json
+++ b/exercises/practice/knapsack/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/knapsack/package.json
+++ b/exercises/practice/knapsack/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/knapsack/tsconfig.json
+++ b/exercises/practice/knapsack/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/largest-series-product/.meta/test-runner.mjs
+++ b/exercises/practice/largest-series-product/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/largest-series-product/package.json
+++ b/exercises/practice/largest-series-product/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/largest-series-product/package.json
+++ b/exercises/practice/largest-series-product/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/largest-series-product/tsconfig.json
+++ b/exercises/practice/largest-series-product/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/leap/.meta/test-runner.mjs
+++ b/exercises/practice/leap/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/leap/package.json
+++ b/exercises/practice/leap/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/leap/package.json
+++ b/exercises/practice/leap/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/leap/tsconfig.json
+++ b/exercises/practice/leap/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/linked-list/.meta/test-runner.mjs
+++ b/exercises/practice/linked-list/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/linked-list/package.json
+++ b/exercises/practice/linked-list/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/linked-list/package.json
+++ b/exercises/practice/linked-list/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/linked-list/tsconfig.json
+++ b/exercises/practice/linked-list/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/list-ops/.meta/test-runner.mjs
+++ b/exercises/practice/list-ops/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/list-ops/package.json
+++ b/exercises/practice/list-ops/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/list-ops/package.json
+++ b/exercises/practice/list-ops/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/list-ops/tsconfig.json
+++ b/exercises/practice/list-ops/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/luhn/.meta/test-runner.mjs
+++ b/exercises/practice/luhn/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/luhn/package.json
+++ b/exercises/practice/luhn/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/luhn/package.json
+++ b/exercises/practice/luhn/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/luhn/tsconfig.json
+++ b/exercises/practice/luhn/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/matching-brackets/.meta/test-runner.mjs
+++ b/exercises/practice/matching-brackets/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/matching-brackets/package.json
+++ b/exercises/practice/matching-brackets/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/matching-brackets/package.json
+++ b/exercises/practice/matching-brackets/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/matching-brackets/tsconfig.json
+++ b/exercises/practice/matching-brackets/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/matrix/.meta/test-runner.mjs
+++ b/exercises/practice/matrix/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/matrix/package.json
+++ b/exercises/practice/matrix/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/matrix/package.json
+++ b/exercises/practice/matrix/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/matrix/tsconfig.json
+++ b/exercises/practice/matrix/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/minesweeper/.meta/test-runner.mjs
+++ b/exercises/practice/minesweeper/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/minesweeper/package.json
+++ b/exercises/practice/minesweeper/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/minesweeper/package.json
+++ b/exercises/practice/minesweeper/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/minesweeper/tsconfig.json
+++ b/exercises/practice/minesweeper/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/nth-prime/.meta/test-runner.mjs
+++ b/exercises/practice/nth-prime/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/nth-prime/package.json
+++ b/exercises/practice/nth-prime/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/nth-prime/package.json
+++ b/exercises/practice/nth-prime/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/nth-prime/tsconfig.json
+++ b/exercises/practice/nth-prime/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/nucleotide-count/.meta/test-runner.mjs
+++ b/exercises/practice/nucleotide-count/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/nucleotide-count/package.json
+++ b/exercises/practice/nucleotide-count/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/nucleotide-count/package.json
+++ b/exercises/practice/nucleotide-count/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/nucleotide-count/tsconfig.json
+++ b/exercises/practice/nucleotide-count/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/ocr-numbers/.meta/test-runner.mjs
+++ b/exercises/practice/ocr-numbers/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/ocr-numbers/package.json
+++ b/exercises/practice/ocr-numbers/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/ocr-numbers/package.json
+++ b/exercises/practice/ocr-numbers/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/ocr-numbers/tsconfig.json
+++ b/exercises/practice/ocr-numbers/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/palindrome-products/.meta/test-runner.mjs
+++ b/exercises/practice/palindrome-products/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/palindrome-products/package.json
+++ b/exercises/practice/palindrome-products/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/palindrome-products/package.json
+++ b/exercises/practice/palindrome-products/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/palindrome-products/tsconfig.json
+++ b/exercises/practice/palindrome-products/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/pangram/.meta/test-runner.mjs
+++ b/exercises/practice/pangram/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/pangram/package.json
+++ b/exercises/practice/pangram/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/pangram/package.json
+++ b/exercises/practice/pangram/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/pangram/tsconfig.json
+++ b/exercises/practice/pangram/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/pascals-triangle/.meta/test-runner.mjs
+++ b/exercises/practice/pascals-triangle/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/pascals-triangle/package.json
+++ b/exercises/practice/pascals-triangle/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/pascals-triangle/package.json
+++ b/exercises/practice/pascals-triangle/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/pascals-triangle/tsconfig.json
+++ b/exercises/practice/pascals-triangle/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/perfect-numbers/.meta/test-runner.mjs
+++ b/exercises/practice/perfect-numbers/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/perfect-numbers/package.json
+++ b/exercises/practice/perfect-numbers/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/perfect-numbers/package.json
+++ b/exercises/practice/perfect-numbers/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/perfect-numbers/tsconfig.json
+++ b/exercises/practice/perfect-numbers/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/phone-number/.meta/test-runner.mjs
+++ b/exercises/practice/phone-number/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/phone-number/package.json
+++ b/exercises/practice/phone-number/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/phone-number/package.json
+++ b/exercises/practice/phone-number/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/phone-number/tsconfig.json
+++ b/exercises/practice/phone-number/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/pig-latin/.meta/test-runner.mjs
+++ b/exercises/practice/pig-latin/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/pig-latin/package.json
+++ b/exercises/practice/pig-latin/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/pig-latin/package.json
+++ b/exercises/practice/pig-latin/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/pig-latin/tsconfig.json
+++ b/exercises/practice/pig-latin/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/prime-factors/.meta/test-runner.mjs
+++ b/exercises/practice/prime-factors/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/prime-factors/package.json
+++ b/exercises/practice/prime-factors/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/prime-factors/package.json
+++ b/exercises/practice/prime-factors/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/prime-factors/tsconfig.json
+++ b/exercises/practice/prime-factors/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/protein-translation/.meta/test-runner.mjs
+++ b/exercises/practice/protein-translation/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/protein-translation/package.json
+++ b/exercises/practice/protein-translation/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/protein-translation/package.json
+++ b/exercises/practice/protein-translation/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/protein-translation/tsconfig.json
+++ b/exercises/practice/protein-translation/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/proverb/.meta/test-runner.mjs
+++ b/exercises/practice/proverb/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/proverb/package.json
+++ b/exercises/practice/proverb/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/proverb/package.json
+++ b/exercises/practice/proverb/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/proverb/tsconfig.json
+++ b/exercises/practice/proverb/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/pythagorean-triplet/.meta/test-runner.mjs
+++ b/exercises/practice/pythagorean-triplet/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/pythagorean-triplet/package.json
+++ b/exercises/practice/pythagorean-triplet/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/pythagorean-triplet/package.json
+++ b/exercises/practice/pythagorean-triplet/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/pythagorean-triplet/tsconfig.json
+++ b/exercises/practice/pythagorean-triplet/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/queen-attack/.meta/test-runner.mjs
+++ b/exercises/practice/queen-attack/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/queen-attack/package.json
+++ b/exercises/practice/queen-attack/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/queen-attack/package.json
+++ b/exercises/practice/queen-attack/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/queen-attack/tsconfig.json
+++ b/exercises/practice/queen-attack/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/raindrops/.meta/test-runner.mjs
+++ b/exercises/practice/raindrops/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/raindrops/package.json
+++ b/exercises/practice/raindrops/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/raindrops/package.json
+++ b/exercises/practice/raindrops/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/raindrops/tsconfig.json
+++ b/exercises/practice/raindrops/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/rational-numbers/.meta/test-runner.mjs
+++ b/exercises/practice/rational-numbers/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/rational-numbers/package.json
+++ b/exercises/practice/rational-numbers/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/rational-numbers/package.json
+++ b/exercises/practice/rational-numbers/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/rational-numbers/tsconfig.json
+++ b/exercises/practice/rational-numbers/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/react/.meta/test-runner.mjs
+++ b/exercises/practice/react/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/react/package.json
+++ b/exercises/practice/react/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/react/package.json
+++ b/exercises/practice/react/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/react/tsconfig.json
+++ b/exercises/practice/react/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/rectangles/.meta/test-runner.mjs
+++ b/exercises/practice/rectangles/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/rectangles/package.json
+++ b/exercises/practice/rectangles/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/rectangles/package.json
+++ b/exercises/practice/rectangles/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/rectangles/tsconfig.json
+++ b/exercises/practice/rectangles/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/resistor-color-duo/.meta/test-runner.mjs
+++ b/exercises/practice/resistor-color-duo/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/resistor-color-duo/package.json
+++ b/exercises/practice/resistor-color-duo/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/resistor-color-duo/package.json
+++ b/exercises/practice/resistor-color-duo/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/resistor-color-duo/tsconfig.json
+++ b/exercises/practice/resistor-color-duo/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/resistor-color-trio/.meta/test-runner.mjs
+++ b/exercises/practice/resistor-color-trio/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/resistor-color-trio/package.json
+++ b/exercises/practice/resistor-color-trio/package.json
@@ -17,17 +17,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/resistor-color-trio/package.json
+++ b/exercises/practice/resistor-color-trio/package.json
@@ -31,7 +31,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/resistor-color-trio/tsconfig.json
+++ b/exercises/practice/resistor-color-trio/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/resistor-color/.meta/test-runner.mjs
+++ b/exercises/practice/resistor-color/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/resistor-color/package.json
+++ b/exercises/practice/resistor-color/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/resistor-color/package.json
+++ b/exercises/practice/resistor-color/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/resistor-color/tsconfig.json
+++ b/exercises/practice/resistor-color/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/reverse-string/.meta/test-runner.mjs
+++ b/exercises/practice/reverse-string/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/reverse-string/package.json
+++ b/exercises/practice/reverse-string/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/reverse-string/package.json
+++ b/exercises/practice/reverse-string/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/reverse-string/tsconfig.json
+++ b/exercises/practice/reverse-string/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/rna-transcription/.meta/test-runner.mjs
+++ b/exercises/practice/rna-transcription/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/rna-transcription/package.json
+++ b/exercises/practice/rna-transcription/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/rna-transcription/package.json
+++ b/exercises/practice/rna-transcription/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/rna-transcription/tsconfig.json
+++ b/exercises/practice/rna-transcription/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/robot-name/.meta/test-runner.mjs
+++ b/exercises/practice/robot-name/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/robot-name/package.json
+++ b/exercises/practice/robot-name/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/robot-name/package.json
+++ b/exercises/practice/robot-name/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/robot-name/tsconfig.json
+++ b/exercises/practice/robot-name/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/robot-simulator/.meta/test-runner.mjs
+++ b/exercises/practice/robot-simulator/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/robot-simulator/package.json
+++ b/exercises/practice/robot-simulator/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/robot-simulator/package.json
+++ b/exercises/practice/robot-simulator/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/robot-simulator/tsconfig.json
+++ b/exercises/practice/robot-simulator/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/roman-numerals/.meta/test-runner.mjs
+++ b/exercises/practice/roman-numerals/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/roman-numerals/package.json
+++ b/exercises/practice/roman-numerals/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/roman-numerals/package.json
+++ b/exercises/practice/roman-numerals/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/roman-numerals/tsconfig.json
+++ b/exercises/practice/roman-numerals/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/rotational-cipher/.meta/test-runner.mjs
+++ b/exercises/practice/rotational-cipher/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/rotational-cipher/package.json
+++ b/exercises/practice/rotational-cipher/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/rotational-cipher/package.json
+++ b/exercises/practice/rotational-cipher/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/rotational-cipher/tsconfig.json
+++ b/exercises/practice/rotational-cipher/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/run-length-encoding/.meta/test-runner.mjs
+++ b/exercises/practice/run-length-encoding/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/run-length-encoding/package.json
+++ b/exercises/practice/run-length-encoding/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/run-length-encoding/package.json
+++ b/exercises/practice/run-length-encoding/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/run-length-encoding/tsconfig.json
+++ b/exercises/practice/run-length-encoding/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/saddle-points/.meta/test-runner.mjs
+++ b/exercises/practice/saddle-points/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/saddle-points/package.json
+++ b/exercises/practice/saddle-points/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/saddle-points/package.json
+++ b/exercises/practice/saddle-points/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/saddle-points/tsconfig.json
+++ b/exercises/practice/saddle-points/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/say/.meta/test-runner.mjs
+++ b/exercises/practice/say/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/say/package.json
+++ b/exercises/practice/say/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/say/package.json
+++ b/exercises/practice/say/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/say/tsconfig.json
+++ b/exercises/practice/say/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/scrabble-score/.meta/test-runner.mjs
+++ b/exercises/practice/scrabble-score/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/scrabble-score/package.json
+++ b/exercises/practice/scrabble-score/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/scrabble-score/package.json
+++ b/exercises/practice/scrabble-score/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/scrabble-score/tsconfig.json
+++ b/exercises/practice/scrabble-score/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/secret-handshake/.meta/test-runner.mjs
+++ b/exercises/practice/secret-handshake/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/secret-handshake/package.json
+++ b/exercises/practice/secret-handshake/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/secret-handshake/package.json
+++ b/exercises/practice/secret-handshake/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/secret-handshake/tsconfig.json
+++ b/exercises/practice/secret-handshake/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/series/.meta/test-runner.mjs
+++ b/exercises/practice/series/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/series/package.json
+++ b/exercises/practice/series/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/series/package.json
+++ b/exercises/practice/series/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/series/tsconfig.json
+++ b/exercises/practice/series/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/sieve/.meta/test-runner.mjs
+++ b/exercises/practice/sieve/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/sieve/package.json
+++ b/exercises/practice/sieve/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/sieve/package.json
+++ b/exercises/practice/sieve/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/sieve/tsconfig.json
+++ b/exercises/practice/sieve/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/simple-cipher/.meta/test-runner.mjs
+++ b/exercises/practice/simple-cipher/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/simple-cipher/package.json
+++ b/exercises/practice/simple-cipher/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/simple-cipher/package.json
+++ b/exercises/practice/simple-cipher/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/simple-cipher/tsconfig.json
+++ b/exercises/practice/simple-cipher/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/space-age/.meta/test-runner.mjs
+++ b/exercises/practice/space-age/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/space-age/package.json
+++ b/exercises/practice/space-age/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/space-age/package.json
+++ b/exercises/practice/space-age/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/space-age/tsconfig.json
+++ b/exercises/practice/space-age/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/spiral-matrix/.meta/test-runner.mjs
+++ b/exercises/practice/spiral-matrix/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/spiral-matrix/package.json
+++ b/exercises/practice/spiral-matrix/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/spiral-matrix/package.json
+++ b/exercises/practice/spiral-matrix/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/spiral-matrix/tsconfig.json
+++ b/exercises/practice/spiral-matrix/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/strain/.meta/test-runner.mjs
+++ b/exercises/practice/strain/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/strain/package.json
+++ b/exercises/practice/strain/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/strain/package.json
+++ b/exercises/practice/strain/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/strain/tsconfig.json
+++ b/exercises/practice/strain/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/sublist/.meta/test-runner.mjs
+++ b/exercises/practice/sublist/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/sublist/package.json
+++ b/exercises/practice/sublist/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/sublist/package.json
+++ b/exercises/practice/sublist/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/sublist/tsconfig.json
+++ b/exercises/practice/sublist/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/sum-of-multiples/.meta/test-runner.mjs
+++ b/exercises/practice/sum-of-multiples/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/sum-of-multiples/package.json
+++ b/exercises/practice/sum-of-multiples/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/sum-of-multiples/package.json
+++ b/exercises/practice/sum-of-multiples/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/sum-of-multiples/tsconfig.json
+++ b/exercises/practice/sum-of-multiples/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/tournament/.meta/test-runner.mjs
+++ b/exercises/practice/tournament/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/tournament/package.json
+++ b/exercises/practice/tournament/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/tournament/package.json
+++ b/exercises/practice/tournament/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/tournament/tsconfig.json
+++ b/exercises/practice/tournament/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/transpose/.meta/test-runner.mjs
+++ b/exercises/practice/transpose/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/transpose/package.json
+++ b/exercises/practice/transpose/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/transpose/package.json
+++ b/exercises/practice/transpose/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/transpose/tsconfig.json
+++ b/exercises/practice/transpose/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/triangle/.meta/test-runner.mjs
+++ b/exercises/practice/triangle/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/triangle/package.json
+++ b/exercises/practice/triangle/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/triangle/package.json
+++ b/exercises/practice/triangle/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/triangle/tsconfig.json
+++ b/exercises/practice/triangle/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/twelve-days/.meta/test-runner.mjs
+++ b/exercises/practice/twelve-days/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/twelve-days/package.json
+++ b/exercises/practice/twelve-days/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/twelve-days/package.json
+++ b/exercises/practice/twelve-days/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/twelve-days/tsconfig.json
+++ b/exercises/practice/twelve-days/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/two-bucket/.meta/test-runner.mjs
+++ b/exercises/practice/two-bucket/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/two-bucket/package.json
+++ b/exercises/practice/two-bucket/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/two-bucket/package.json
+++ b/exercises/practice/two-bucket/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/two-bucket/tsconfig.json
+++ b/exercises/practice/two-bucket/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/two-fer/.meta/test-runner.mjs
+++ b/exercises/practice/two-fer/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/two-fer/package.json
+++ b/exercises/practice/two-fer/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/two-fer/package.json
+++ b/exercises/practice/two-fer/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/two-fer/tsconfig.json
+++ b/exercises/practice/two-fer/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/variable-length-quantity/.meta/test-runner.mjs
+++ b/exercises/practice/variable-length-quantity/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/variable-length-quantity/package.json
+++ b/exercises/practice/variable-length-quantity/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/variable-length-quantity/package.json
+++ b/exercises/practice/variable-length-quantity/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/variable-length-quantity/tsconfig.json
+++ b/exercises/practice/variable-length-quantity/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/word-count/.meta/test-runner.mjs
+++ b/exercises/practice/word-count/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/word-count/package.json
+++ b/exercises/practice/word-count/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/word-count/package.json
+++ b/exercises/practice/word-count/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/word-count/tsconfig.json
+++ b/exercises/practice/word-count/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/word-search/.meta/test-runner.mjs
+++ b/exercises/practice/word-search/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/word-search/package.json
+++ b/exercises/practice/word-search/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/word-search/package.json
+++ b/exercises/practice/word-search/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/word-search/tsconfig.json
+++ b/exercises/practice/word-search/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/exercises/practice/wordy/.meta/test-runner.mjs
+++ b/exercises/practice/wordy/.meta/test-runner.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process'
+// Experimental: import config from './config.json' with { type: 'json' }
+
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+
+/** @type {import('./config.json') } */
+const config = JSON.parse(
+  readFileSync(new URL('./config.json', import.meta.url))
+)
+
+const jest = !config.custom || config.custom['flag.tests.jest']
+const tstyche = config.custom?.['flag.tests.tstyche']
+
+console.log(
+  `[tests] tsc: ✅, tstyche: ${tstyche ? '✅' : '❌'}, jest: ${jest ? '✅' : '❌'}, `
+)
+
+console.log('[tests] tsc (compile)')
+
+try {
+  execSync('corepack yarn lint:types', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+} catch {
+  exit(-1)
+}
+
+if (tstyche) {
+  console.log('[tests] tstyche (type tests)')
+
+  try {
+    execSync('corepack yarn test:types', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-2)
+  }
+}
+
+if (jest) {
+  console.log('[tests] tstyche (implementation tests)')
+
+  try {
+    execSync('corepack yarn test:implementation', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    })
+  } catch {
+    exit(-3)
+  }
+}

--- a/exercises/practice/wordy/package.json
+++ b/exercises/practice/wordy/package.json
@@ -13,17 +13,18 @@
   },
   "devDependencies": {
     "@exercism/babel-preset-typescript": "^0.5.0",
-    "@exercism/eslint-config-typescript": "^0.7.0",
+    "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "core-js": "~3.37.1",
     "eslint": "^9.8.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "tstyche": "^2.1.1",
     "typescript": "~5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^7.18.0"
   },
   "scripts": {
     "test": "corepack yarn lint:types && jest --no-cache",

--- a/exercises/practice/wordy/package.json
+++ b/exercises/practice/wordy/package.json
@@ -27,7 +27,9 @@
     "typescript-eslint": "^7.18.0"
   },
   "scripts": {
-    "test": "corepack yarn lint:types && jest --no-cache",
+    "test": "corepack yarn node .meta/test-runner.mjs",
+    "test:types": "corepack yarn tstyche",
+    "test:implementation": "corepack yarn jest --no-cache --passWithNoTests",
     "lint": "corepack yarn lint:types && corepack yarn lint:ci",
     "lint:types": "corepack yarn tsc --noEmit -p .",
     "lint:ci": "corepack yarn eslint . --ext .tsx,.ts"

--- a/exercises/practice/wordy/tsconfig.json
+++ b/exercises/practice/wordy/tsconfig.json
@@ -27,6 +27,12 @@
     // https://babeljs.io/docs/en/babel-plugin-transform-typescript/#caveats
     "isolatedModules": true
   },
-  "include": ["*.ts", "*.tsx", ".meta/*.ts", ".meta/*.tsx"],
+  "include": [
+    "*.ts",
+    "*.tsx",
+    ".meta/*.ts",
+    ".meta/*.tsx",
+    "__typetests__/*.tst.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@exercism/eslint-config-typescript": "^0.7.1",
     "@jest/globals": "^29.7.0",
     "@tsconfig/node20": "^20.1.4",
-    "@types/node": "~22.0.0",
+    "@types/node": "~22.0.2",
     "babel-jest": "^29.7.0",
     "chalk": "^5.3.0",
     "core-js": "~3.37.1",
@@ -43,5 +43,8 @@
     "test": "corepack yarn node scripts/test.mjs",
     "format": "corepack yarn node scripts/format.mjs"
   },
-  "packageManager": "yarn@4.3.1"
+  "packageManager": "yarn@4.3.1",
+  "dependencies": {
+    "tstyche": "^2.1.1"
+  }
 }

--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -23,6 +23,7 @@ export const COMMON_DIR_COPY_CONTENTS = [
   // '.vscode',
 ]
 export const COMMON_FILES = [
+  '.meta/test-runner.mjs',
   '.vscode/extensions.json',
   '.vscode/settings.json',
   '.yarnrc.yml',

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -25,7 +25,7 @@ shell.env['PREPARE'] = true
 shell.env['CLEANUP'] = true
 
 helpers.prepareAndRun(
-  'corepack yarn jest --bail tmp_exercises',
+  'corepack yarn tstyche tmp_exercises --failFast && corepack yarn jest --bail tmp_exercises',
   infoStr,
   failureStr
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,71 +5,17 @@ __metadata:
   version: 8
   cacheKey: 10
 
-"@aashutoshrathi/word-wrap@npm:^1.2.3":
-  version: 1.2.6
-  resolution: "@aashutoshrathi/word-wrap@npm:1.2.6"
-  checksum: 10/6eebd12a5cd03cee38fcb915ef9f4ea557df6a06f642dfc7fe8eb4839eb5c9ca55a382f3604d52c14200b0c214c12af5e1f23d2a6d8e23ef2d016b105a9d6c0a
-  languageName: node
-  linkType: hard
-
-"@ampproject/remapping@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "@ampproject/remapping@npm:2.1.1"
-  dependencies:
-    "@jridgewell/trace-mapping": "npm:^0.3.0"
-  checksum: 10/58b9f4f19cdf47f5a157b553d0dcdc5169b3bda8db668e89f853455e90c8d619ac8009ed16ae6f97c15e9684bf3c1cffc3baed8e3458688b9d210a7f03ae4f70
-  languageName: node
-  linkType: hard
-
-"@ampproject/remapping@npm:^2.1.0":
-  version: 2.2.0
-  resolution: "@ampproject/remapping@npm:2.2.0"
-  dependencies:
-    "@jridgewell/gen-mapping": "npm:^0.1.0"
-    "@jridgewell/trace-mapping": "npm:^0.3.9"
-  checksum: 10/503a58d6e9d645a20debd34fa8df79fb435a79a34b1d487b9ff0be9f20712b1594ce21da16b63af7db8a6b34472212572e53a55613a5a6b3134b23fc74843d04
-  languageName: node
-  linkType: hard
-
 "@ampproject/remapping@npm:^2.2.0":
-  version: 2.2.1
-  resolution: "@ampproject/remapping@npm:2.2.1"
+  version: 2.3.0
+  resolution: "@ampproject/remapping@npm:2.3.0"
   dependencies:
-    "@jridgewell/gen-mapping": "npm:^0.3.0"
-    "@jridgewell/trace-mapping": "npm:^0.3.9"
-  checksum: 10/e15fecbf3b54c988c8b4fdea8ef514ab482537e8a080b2978cc4b47ccca7140577ca7b65ad3322dcce65bc73ee6e5b90cbfe0bbd8c766dad04d5c62ec9634c42
+    "@jridgewell/gen-mapping": "npm:^0.3.5"
+    "@jridgewell/trace-mapping": "npm:^0.3.24"
+  checksum: 10/f3451525379c68a73eb0a1e65247fbf28c0cccd126d93af21c75fceff77773d43c0d4a2d51978fb131aff25b5f2cb41a9fe48cc296e61ae65e679c4f6918b0ab
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.14.5":
-  version: 7.14.5
-  resolution: "@babel/code-frame@npm:7.14.5"
-  dependencies:
-    "@babel/highlight": "npm:^7.14.5"
-  checksum: 10/0adbe4f8d91586f764f524e57631f582ab988b2ef504391a5d89db29bfaaf7c67c237798ed4a249b6a2d7135852cf94d3d07ce6b9739dd1df1f271d5ed069565
-  languageName: node
-  linkType: hard
-
-"@babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/code-frame@npm:7.16.7"
-  dependencies:
-    "@babel/highlight": "npm:^7.16.7"
-  checksum: 10/db2f7faa31bc2c9cf63197b481b30ea57147a5fc1a6fab60e5d6c02cdfbf6de8e17b5121f99917b3dabb5eeb572da078312e70697415940383efc140d4e0808b
-  languageName: node
-  linkType: hard
-
-"@babel/code-frame@npm:^7.23.5, @babel/code-frame@npm:^7.24.1":
-  version: 7.24.2
-  resolution: "@babel/code-frame@npm:7.24.2"
-  dependencies:
-    "@babel/highlight": "npm:^7.24.2"
-    picocolors: "npm:^1.0.0"
-  checksum: 10/7db8f5b36ffa3f47a37f58f61e3d130b9ecad21961f3eede7e2a4ac2c7e4a5efb6e9d03a810c669bc986096831b6c0dfc2c3082673d93351b82359c1b03e0590
-  languageName: node
-  linkType: hard
-
-"@babel/code-frame@npm:^7.24.7":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/code-frame@npm:7.24.7"
   dependencies:
@@ -79,131 +25,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.16.4":
-  version: 7.16.4
-  resolution: "@babel/compat-data@npm:7.16.4"
-  checksum: 10/97369bab0feacd0c23bace3153fb4942c7d6a856fd8cda3ab315de985778596dbf9f2d1752bd6d338993ae4018617caa62a24f4625874d896e9b275d229ff4a3
+"@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.25.2":
+  version: 7.25.2
+  resolution: "@babel/compat-data@npm:7.25.2"
+  checksum: 10/fd61de9303db3177fc98173571f81f3f551eac5c9f839c05ad02818b11fe77a74daa632abebf7f423fbb4a29976ae9141e0d2bd7517746a0ff3d74cb659ad33a
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.17.10":
-  version: 7.17.10
-  resolution: "@babel/compat-data@npm:7.17.10"
-  checksum: 10/aae484b855a407767bbf902cc4a6863998737a8a41a95e76e4903f7bc42d86e4aeffdda40d9ed2167bf03c0dfc5a9b047acd2179fa3a3a5ee086035c8d60e637
-  languageName: node
-  linkType: hard
-
-"@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.24.8, @babel/compat-data@npm:^7.25.0":
-  version: 7.25.0
-  resolution: "@babel/compat-data@npm:7.25.0"
-  checksum: 10/35cb500c85084bc09d4385134c64cb0030df750c502e1d78d674e7b059c3e545286e3449163b3812e94098096982f5162f72fb13afd2d2161f4da5076cf2194e
-  languageName: node
-  linkType: hard
-
-"@babel/core@npm:^7.11.6":
-  version: 7.17.10
-  resolution: "@babel/core@npm:7.17.10"
-  dependencies:
-    "@ampproject/remapping": "npm:^2.1.0"
-    "@babel/code-frame": "npm:^7.16.7"
-    "@babel/generator": "npm:^7.17.10"
-    "@babel/helper-compilation-targets": "npm:^7.17.10"
-    "@babel/helper-module-transforms": "npm:^7.17.7"
-    "@babel/helpers": "npm:^7.17.9"
-    "@babel/parser": "npm:^7.17.10"
-    "@babel/template": "npm:^7.16.7"
-    "@babel/traverse": "npm:^7.17.10"
-    "@babel/types": "npm:^7.17.10"
-    convert-source-map: "npm:^1.7.0"
-    debug: "npm:^4.1.0"
-    gensync: "npm:^1.0.0-beta.2"
-    json5: "npm:^2.2.1"
-    semver: "npm:^6.3.0"
-  checksum: 10/018b40bb6f2e34317af4682eae2e60e088b67f2d7c3540333a35c62c158f0ca28ec9084484a1a954a73284bb3671db9435b0d09e76fff90f88463324fee9b1a6
-  languageName: node
-  linkType: hard
-
-"@babel/core@npm:^7.12.3":
-  version: 7.17.2
-  resolution: "@babel/core@npm:7.17.2"
-  dependencies:
-    "@ampproject/remapping": "npm:^2.0.0"
-    "@babel/code-frame": "npm:^7.16.7"
-    "@babel/generator": "npm:^7.17.0"
-    "@babel/helper-compilation-targets": "npm:^7.16.7"
-    "@babel/helper-module-transforms": "npm:^7.16.7"
-    "@babel/helpers": "npm:^7.17.2"
-    "@babel/parser": "npm:^7.17.0"
-    "@babel/template": "npm:^7.16.7"
-    "@babel/traverse": "npm:^7.17.0"
-    "@babel/types": "npm:^7.17.0"
-    convert-source-map: "npm:^1.7.0"
-    debug: "npm:^4.1.0"
-    gensync: "npm:^1.0.0-beta.2"
-    json5: "npm:^2.1.2"
-    semver: "npm:^6.3.0"
-  checksum: 10/d5642ed4b2febb7d6a6459b78f50bed70054c763796a4342b5c9fbd84ad21f27730de86a3d21d456336328c9d11035202b4894636890bd9d3038a8594b1c1282
-  languageName: node
-  linkType: hard
-
-"@babel/core@npm:^7.23.9, @babel/core@npm:^7.24.9":
-  version: 7.24.9
-  resolution: "@babel/core@npm:7.24.9"
+"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.23.9, @babel/core@npm:^7.24.9":
+  version: 7.25.2
+  resolution: "@babel/core@npm:7.25.2"
   dependencies:
     "@ampproject/remapping": "npm:^2.2.0"
     "@babel/code-frame": "npm:^7.24.7"
-    "@babel/generator": "npm:^7.24.9"
-    "@babel/helper-compilation-targets": "npm:^7.24.8"
-    "@babel/helper-module-transforms": "npm:^7.24.9"
-    "@babel/helpers": "npm:^7.24.8"
-    "@babel/parser": "npm:^7.24.8"
-    "@babel/template": "npm:^7.24.7"
-    "@babel/traverse": "npm:^7.24.8"
-    "@babel/types": "npm:^7.24.9"
+    "@babel/generator": "npm:^7.25.0"
+    "@babel/helper-compilation-targets": "npm:^7.25.2"
+    "@babel/helper-module-transforms": "npm:^7.25.2"
+    "@babel/helpers": "npm:^7.25.0"
+    "@babel/parser": "npm:^7.25.0"
+    "@babel/template": "npm:^7.25.0"
+    "@babel/traverse": "npm:^7.25.2"
+    "@babel/types": "npm:^7.25.2"
     convert-source-map: "npm:^2.0.0"
     debug: "npm:^4.1.0"
     gensync: "npm:^1.0.0-beta.2"
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
-  checksum: 10/f00a372fa547f6e21f4db1b6e521e6eb01f77f5931726897aae6f4cf29a687f615b9b77147b539e851a68bf94e4850bcfba7eb11091dd8e2bc625f6d831ce257
+  checksum: 10/0d6ec10ff430df66f654c089d6f7ef1d9bed0c318ac257ad5f0dfa0caa45666011828ae75f998bcdb279763e892b091b2925d0bc483299e61649d2c7a2245e33
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.17.0, @babel/generator@npm:^7.7.2":
-  version: 7.17.0
-  resolution: "@babel/generator@npm:7.17.0"
-  dependencies:
-    "@babel/types": "npm:^7.17.0"
-    jsesc: "npm:^2.5.1"
-    source-map: "npm:^0.5.0"
-  checksum: 10/0edc168c4c84fe47e972cbcd387b67c6f3ae11a0a2f02d09d9786f55f0dfb53a4ac437cee18336b7f5fe2d037026ab818b656b2c69afdde4cd2eda2479e02f10
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.17.10":
-  version: 7.17.10
-  resolution: "@babel/generator@npm:7.17.10"
-  dependencies:
-    "@babel/types": "npm:^7.17.10"
-    "@jridgewell/gen-mapping": "npm:^0.1.0"
-    jsesc: "npm:^2.5.1"
-  checksum: 10/32fa924433681d8122aa30a0833d4b25d400d075d143920f559352c066db4e656362d1863cfce316034d424f6345df8a64909cb2a8386e96198cc0ca18d6c4aa
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.24.1":
-  version: 7.24.4
-  resolution: "@babel/generator@npm:7.24.4"
-  dependencies:
-    "@babel/types": "npm:^7.24.0"
-    "@jridgewell/gen-mapping": "npm:^0.3.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    jsesc: "npm:^2.5.1"
-  checksum: 10/69e1772dcf8f95baec951f422cca091d59a3f29b5eedc989ad87f7262289b94625983f6fe654302ca17aae0a32f9232332b83fcc85533311d6267b09c58b1061
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.24.9, @babel/generator@npm:^7.25.0":
+"@babel/generator@npm:^7.25.0, @babel/generator@npm:^7.7.2":
   version: 7.25.0
   resolution: "@babel/generator@npm:7.25.0"
   dependencies:
@@ -212,15 +64,6 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     jsesc: "npm:^2.5.1"
   checksum: 10/de3ce2ae7aa0c9585260556ca5a81ce2ce6b8269e3260d7bb4e47a74661af715184ca6343e9906c22e4dd3eed5ce39977dfaf6cded4d2d8968fa096c7cf66697
-  languageName: node
-  linkType: hard
-
-"@babel/helper-annotate-as-pure@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-annotate-as-pure@npm:7.18.6"
-  dependencies:
-    "@babel/types": "npm:^7.18.6"
-  checksum: 10/88ccd15ced475ef2243fdd3b2916a29ea54c5db3cd0cfabf9d1d29ff6e63b7f7cd1c27264137d7a40ac2e978b9b9a542c332e78f40eb72abe737a7400788fc1b
   languageName: node
   linkType: hard
 
@@ -243,44 +86,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/helper-compilation-targets@npm:7.16.7"
+"@babel/helper-compilation-targets@npm:^7.22.6, @babel/helper-compilation-targets@npm:^7.24.7, @babel/helper-compilation-targets@npm:^7.24.8, @babel/helper-compilation-targets@npm:^7.25.2":
+  version: 7.25.2
+  resolution: "@babel/helper-compilation-targets@npm:7.25.2"
   dependencies:
-    "@babel/compat-data": "npm:^7.16.4"
-    "@babel/helper-validator-option": "npm:^7.16.7"
-    browserslist: "npm:^4.17.5"
-    semver: "npm:^6.3.0"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10/87cd35911856e03fa45a0593a36e5f20bec745dbb2f82e0689dc09f4607a13c225d9295e26e7bf44b178f323a3bccad0c025be7e7c32564bcd0a08b2e9ab727d
-  languageName: node
-  linkType: hard
-
-"@babel/helper-compilation-targets@npm:^7.17.10":
-  version: 7.17.10
-  resolution: "@babel/helper-compilation-targets@npm:7.17.10"
-  dependencies:
-    "@babel/compat-data": "npm:^7.17.10"
-    "@babel/helper-validator-option": "npm:^7.16.7"
-    browserslist: "npm:^4.20.2"
-    semver: "npm:^6.3.0"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10/2d431a0cc01e384d72afd10fa80e94a4e47f85fdb235309e5ebe64758c4ef3ef587a7b517ec1a2a0fd4c64bcbb96e2340f252276fcd32c10e24124f5869838ad
-  languageName: node
-  linkType: hard
-
-"@babel/helper-compilation-targets@npm:^7.22.6, @babel/helper-compilation-targets@npm:^7.24.7, @babel/helper-compilation-targets@npm:^7.24.8":
-  version: 7.24.8
-  resolution: "@babel/helper-compilation-targets@npm:7.24.8"
-  dependencies:
-    "@babel/compat-data": "npm:^7.24.8"
+    "@babel/compat-data": "npm:^7.25.2"
     "@babel/helper-validator-option": "npm:^7.24.8"
     browserslist: "npm:^4.23.1"
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
-  checksum: 10/3489280d07b871af565b32f9b11946ff9a999fac0db9bec5df960760f6836c7a4b52fccb9d64229ccce835d37a43afb85659beb439ecedde04dcea7eb062a143
+  checksum: 10/eccb2d75923d2d4d596f9ff64716e8664047c4192f1b44c7d5c07701d4a3498ac2587a72ddae1046e65a501bc630eb7df4557958b08ec2dcf5b4a264a052f111
   languageName: node
   linkType: hard
 
@@ -301,29 +116,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-regexp-features-plugin@npm:^7.18.6":
-  version: 7.22.1
-  resolution: "@babel/helper-create-regexp-features-plugin@npm:7.22.1"
-  dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.18.6"
-    regexpu-core: "npm:^5.3.1"
-    semver: "npm:^6.3.0"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10/464af32e0be268703c3376cf2499f721c0579d66b77462feff8bcbf9e399b85145322138ac290668fb766eb34f295ed362a39d30c73e8c695ccfe31067e13a47
-  languageName: node
-  linkType: hard
-
-"@babel/helper-create-regexp-features-plugin@npm:^7.24.7, @babel/helper-create-regexp-features-plugin@npm:^7.25.0":
-  version: 7.25.0
-  resolution: "@babel/helper-create-regexp-features-plugin@npm:7.25.0"
+"@babel/helper-create-regexp-features-plugin@npm:^7.18.6, @babel/helper-create-regexp-features-plugin@npm:^7.24.7, @babel/helper-create-regexp-features-plugin@npm:^7.25.0":
+  version: 7.25.2
+  resolution: "@babel/helper-create-regexp-features-plugin@npm:7.25.2"
   dependencies:
     "@babel/helper-annotate-as-pure": "npm:^7.24.7"
     regexpu-core: "npm:^5.3.1"
     semver: "npm:^6.3.1"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10/591a860396911b4264a82afe43c2bedbc35660570ae1891074d86153785b660bb42b1b075aa996ade70fc4b99e5cbfd7bb52c0c8ba00856a04a0a69dfb4b9ed9
+  checksum: 10/33dd627eef9e4229aba66789efd8fb7342fc2667b821d4b7947c7294f6d472cf025ff2db9b358a1e03de98376de44e839f0611a456a57127fd6e4b4dbfc96c51
   languageName: node
   linkType: hard
 
@@ -342,41 +144,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-environment-visitor@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/helper-environment-visitor@npm:7.16.7"
-  dependencies:
-    "@babel/types": "npm:^7.16.7"
-  checksum: 10/c03a10105d9ebd1fe632a77356b2e6e2f3c44edba9a93b0dc3591b6a66bd7a2e323dd9502f9ce96fc6401234abff1907aa877b6674f7826b61c953f7c8204bbe
-  languageName: node
-  linkType: hard
-
-"@babel/helper-environment-visitor@npm:^7.22.20":
-  version: 7.22.20
-  resolution: "@babel/helper-environment-visitor@npm:7.22.20"
-  checksum: 10/d80ee98ff66f41e233f36ca1921774c37e88a803b2f7dca3db7c057a5fea0473804db9fb6729e5dbfd07f4bed722d60f7852035c2c739382e84c335661590b69
-  languageName: node
-  linkType: hard
-
-"@babel/helper-function-name@npm:^7.23.0":
-  version: 7.23.0
-  resolution: "@babel/helper-function-name@npm:7.23.0"
-  dependencies:
-    "@babel/template": "npm:^7.22.15"
-    "@babel/types": "npm:^7.23.0"
-  checksum: 10/7b2ae024cd7a09f19817daf99e0153b3bf2bc4ab344e197e8d13623d5e36117ed0b110914bc248faa64e8ccd3e97971ec7b41cc6fd6163a2b980220c58dcdf6d
-  languageName: node
-  linkType: hard
-
-"@babel/helper-hoist-variables@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/helper-hoist-variables@npm:7.22.5"
-  dependencies:
-    "@babel/types": "npm:^7.22.5"
-  checksum: 10/394ca191b4ac908a76e7c50ab52102669efe3a1c277033e49467913c7ed6f7c64d7eacbeabf3bed39ea1f41731e22993f763b1edce0f74ff8563fd1f380d92cc
-  languageName: node
-  linkType: hard
-
 "@babel/helper-member-expression-to-functions@npm:^7.24.8":
   version: 7.24.8
   resolution: "@babel/helper-member-expression-to-functions@npm:7.24.8"
@@ -384,15 +151,6 @@ __metadata:
     "@babel/traverse": "npm:^7.24.8"
     "@babel/types": "npm:^7.24.8"
   checksum: 10/ac878761cfd0a46c081cda0da75cc186f922cf16e8ecdd0c4fb6dca4330d9fe4871b41a9976224cf9669c9e7fe0421b5c27349f2e99c125fa0be871b327fa770
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-imports@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/helper-module-imports@npm:7.16.7"
-  dependencies:
-    "@babel/types": "npm:^7.16.7"
-  checksum: 10/f48cb485be7cad70c3fdcbc1d6d104732565288fe5dd38575be4b6dd577aa606a0e7553078cebf91bea5182e1b059bcc5b6882cd1f8ccb9013d6c76b6ff136ff
   languageName: node
   linkType: hard
 
@@ -406,49 +164,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/helper-module-transforms@npm:7.16.7"
-  dependencies:
-    "@babel/helper-environment-visitor": "npm:^7.16.7"
-    "@babel/helper-module-imports": "npm:^7.16.7"
-    "@babel/helper-simple-access": "npm:^7.16.7"
-    "@babel/helper-split-export-declaration": "npm:^7.16.7"
-    "@babel/helper-validator-identifier": "npm:^7.16.7"
-    "@babel/template": "npm:^7.16.7"
-    "@babel/traverse": "npm:^7.16.7"
-    "@babel/types": "npm:^7.16.7"
-  checksum: 10/e2eb158c6809c43d2886249115bc2b6d2e91e21aaaa93ebbeceac0d7cbfe0af0e7ceb157184c26d6ac0aec24f868ab8933b902745dcfd2d25a40284b968c7173
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-transforms@npm:^7.17.7":
-  version: 7.17.7
-  resolution: "@babel/helper-module-transforms@npm:7.17.7"
-  dependencies:
-    "@babel/helper-environment-visitor": "npm:^7.16.7"
-    "@babel/helper-module-imports": "npm:^7.16.7"
-    "@babel/helper-simple-access": "npm:^7.17.7"
-    "@babel/helper-split-export-declaration": "npm:^7.16.7"
-    "@babel/helper-validator-identifier": "npm:^7.16.7"
-    "@babel/template": "npm:^7.16.7"
-    "@babel/traverse": "npm:^7.17.3"
-    "@babel/types": "npm:^7.17.0"
-  checksum: 10/d11a4adbc3fa14b94d9fb7db96f87a268c31b5ce4e4d112e62ef23c7f54154b941869cf6065a844b656bf0c51f998793006c21e607d5415b62dc0c33de7a8359
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-transforms@npm:^7.24.7, @babel/helper-module-transforms@npm:^7.24.8, @babel/helper-module-transforms@npm:^7.24.9, @babel/helper-module-transforms@npm:^7.25.0":
-  version: 7.25.0
-  resolution: "@babel/helper-module-transforms@npm:7.25.0"
+"@babel/helper-module-transforms@npm:^7.24.7, @babel/helper-module-transforms@npm:^7.24.8, @babel/helper-module-transforms@npm:^7.25.0, @babel/helper-module-transforms@npm:^7.25.2":
+  version: 7.25.2
+  resolution: "@babel/helper-module-transforms@npm:7.25.2"
   dependencies:
     "@babel/helper-module-imports": "npm:^7.24.7"
     "@babel/helper-simple-access": "npm:^7.24.7"
     "@babel/helper-validator-identifier": "npm:^7.24.7"
-    "@babel/traverse": "npm:^7.25.0"
+    "@babel/traverse": "npm:^7.25.2"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10/c1668f96d13815780b7e146faff67061d24f16c16e923894bfa2eb0cd8c051ece49e0e41bdcaba9660a744a6ee496b7de0c92f205961c0dba710b851a805477f
+  checksum: 10/a3bcf7815f3e9d8b205e0af4a8d92603d685868e45d119b621357e274996bf916216bb95ab5c6a60fde3775b91941555bf129d608e3d025b04f8aac84589f300
   languageName: node
   linkType: hard
 
@@ -461,28 +187,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.8.0, @babel/helper-plugin-utils@npm:^7.8.3":
-  version: 7.14.5
-  resolution: "@babel/helper-plugin-utils@npm:7.14.5"
-  checksum: 10/fe20e90a24d02770a60ebe80ab9f0dfd7258503cea8006c71709ac9af1aa3e47b0de569499673f11ea6c99597f8c0e4880ae1d505986e61101b69716820972fe
-  languageName: node
-  linkType: hard
-
-"@babel/helper-plugin-utils@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/helper-plugin-utils@npm:7.16.7"
-  checksum: 10/d08dd86554a186c2538547cd537552e4029f704994a9201d41d82015c10ed7f58f9036e8d1527c3760f042409163269d308b0b3706589039c5f1884619c6d4ce
-  languageName: node
-  linkType: hard
-
-"@babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.20.2":
-  version: 7.21.5
-  resolution: "@babel/helper-plugin-utils@npm:7.21.5"
-  checksum: 10/e84986c6e17451f3868ad6a94176f40e96fde77ab89e266ab6f5d3e776544d2d5cbe003767dfef15c6de461f0dc0688000a52c1c6dae4ee9157ed8acfc46bf0e
-  languageName: node
-  linkType: hard
-
-"@babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.24.7, @babel/helper-plugin-utils@npm:^7.24.8":
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.24.7, @babel/helper-plugin-utils@npm:^7.24.8, @babel/helper-plugin-utils@npm:^7.8.0, @babel/helper-plugin-utils@npm:^7.8.3":
   version: 7.24.8
   resolution: "@babel/helper-plugin-utils@npm:7.24.8"
   checksum: 10/adbc9fc1142800a35a5eb0793296924ee8057fe35c61657774208670468a9fbfbb216f2d0bc46c680c5fefa785e5ff917cc1674b10bd75cdf9a6aa3444780630
@@ -515,24 +220,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-simple-access@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/helper-simple-access@npm:7.16.7"
-  dependencies:
-    "@babel/types": "npm:^7.16.7"
-  checksum: 10/8d22c46c5ec2ead0686c4d5a3d1d12b5190c59be676bfe0d9d89df62b437b51d1a3df2ccfb8a77dded2e585176ebf12986accb6d45a18cff229eef3b10344f4b
-  languageName: node
-  linkType: hard
-
-"@babel/helper-simple-access@npm:^7.17.7":
-  version: 7.17.7
-  resolution: "@babel/helper-simple-access@npm:7.17.7"
-  dependencies:
-    "@babel/types": "npm:^7.17.0"
-  checksum: 10/58a9bfd054720024f6ff47fbb113c96061dc2bd31a5e5285756bd3c2e83918c6926900e00150d0fb175d899494fe7d69bf2a8b278c32ef6f6bea8d032e6a3831
-  languageName: node
-  linkType: hard
-
 "@babel/helper-simple-access@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-simple-access@npm:7.24.7"
@@ -553,38 +240,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-split-export-declaration@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/helper-split-export-declaration@npm:7.16.7"
-  dependencies:
-    "@babel/types": "npm:^7.16.7"
-  checksum: 10/e10aaf135465c55114627951b79115f24bc7af72ecbb58d541d66daf1edaee5dde7cae3ec8c3639afaf74526c03ae3ce723444e3b5b3dc77140c456cd84bcaa1
-  languageName: node
-  linkType: hard
-
-"@babel/helper-split-export-declaration@npm:^7.22.6":
-  version: 7.22.6
-  resolution: "@babel/helper-split-export-declaration@npm:7.22.6"
-  dependencies:
-    "@babel/types": "npm:^7.22.5"
-  checksum: 10/e141cace583b19d9195f9c2b8e17a3ae913b7ee9b8120246d0f9ca349ca6f03cb2c001fd5ec57488c544347c0bb584afec66c936511e447fd20a360e591ac921
-  languageName: node
-  linkType: hard
-
-"@babel/helper-string-parser@npm:^7.21.5":
-  version: 7.21.5
-  resolution: "@babel/helper-string-parser@npm:7.21.5"
-  checksum: 10/8295bfa30bb84aabaf9a6243ddc2722ed8685ff3aa17ca967f71ced45bfa1ecf9fc3d88c6069de1e19ebfec50a70fa76237c8104208ca25629ab6f67f401ae9e
-  languageName: node
-  linkType: hard
-
-"@babel/helper-string-parser@npm:^7.23.4":
-  version: 7.24.1
-  resolution: "@babel/helper-string-parser@npm:7.24.1"
-  checksum: 10/04c0ede77b908b43e6124753b48bc485528112a9335f0a21a226bff1ace75bb6e64fab24c85cb4b1610ef3494dacd1cb807caeb6b79a7b36c43d48c289b35949
-  languageName: node
-  linkType: hard
-
 "@babel/helper-string-parser@npm:^7.24.8":
   version: 7.24.8
   resolution: "@babel/helper-string-parser@npm:7.24.8"
@@ -592,38 +247,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/helper-validator-identifier@npm:7.16.7"
-  checksum: 10/42b9b56c3543ded08992e8c118cb017dbde258895bd6a2e69186cb98f4f5811cd94ceedf4b5ace4877e7be07a7280aa9b9de65d1cb416064a1e0e1fd5a89fcca
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-identifier@npm:^7.19.1":
-  version: 7.19.1
-  resolution: "@babel/helper-validator-identifier@npm:7.19.1"
-  checksum: 10/30ecd53b7276970d59d65e68e147ea885f8812e50d06a59315dd1f12dc41467d29d6c56bf1fd02e91100f939cba378815b2c19f5d3604331a153aed9efcbd2a9
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-identifier@npm:^7.22.20":
-  version: 7.22.20
-  resolution: "@babel/helper-validator-identifier@npm:7.22.20"
-  checksum: 10/df882d2675101df2d507b95b195ca2f86a3ef28cb711c84f37e79ca23178e13b9f0d8b522774211f51e40168bf5142be4c1c9776a150cddb61a0d5bf3e95750b
-  languageName: node
-  linkType: hard
-
 "@babel/helper-validator-identifier@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-validator-identifier@npm:7.24.7"
   checksum: 10/86875063f57361471b531dbc2ea10bbf5406e12b06d249b03827d361db4cad2388c6f00936bcd9dc86479f7e2c69ea21412c2228d4b3672588b754b70a449d4b
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-option@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/helper-validator-option@npm:7.16.7"
-  checksum: 10/c5ccc451911883cc9f12125d47be69434f28094475c1b9d2ada7c3452e6ac98a1ee8ddd364ca9e3f9855fcdee96cdeafa32543ebd9d17fee7a1062c202e80570
   languageName: node
   linkType: hard
 
@@ -645,58 +272,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.17.2":
-  version: 7.17.2
-  resolution: "@babel/helpers@npm:7.17.2"
-  dependencies:
-    "@babel/template": "npm:^7.16.7"
-    "@babel/traverse": "npm:^7.17.0"
-    "@babel/types": "npm:^7.17.0"
-  checksum: 10/02c8b0b5f1e37bd4e1fc2505ab7925ebdf3a86e31e6e56f7dc34dee5ed7cd559d42c07b7776ccfcd80412f14b596e2e70b1edc211d8b0e6e59125db0af320201
-  languageName: node
-  linkType: hard
-
-"@babel/helpers@npm:^7.17.9":
-  version: 7.17.9
-  resolution: "@babel/helpers@npm:7.17.9"
-  dependencies:
-    "@babel/template": "npm:^7.16.7"
-    "@babel/traverse": "npm:^7.17.9"
-    "@babel/types": "npm:^7.17.0"
-  checksum: 10/43abc513da845f54904b1adb8f1d4e74e626565ddb7046babefb6c1c6906d89141f352b1b108bec0d2549ef134e7778df0135a322f2113d4bf1edb52c3351c4b
-  languageName: node
-  linkType: hard
-
-"@babel/helpers@npm:^7.24.8":
+"@babel/helpers@npm:^7.25.0":
   version: 7.25.0
   resolution: "@babel/helpers@npm:7.25.0"
   dependencies:
     "@babel/template": "npm:^7.25.0"
     "@babel/types": "npm:^7.25.0"
   checksum: 10/4fcb8167eba9853e30b8b235b81b923ef7b707396b0e23d7a4fa3e811729506755576cb9ec736e8b92cf19e5a1ec61e83d182904d8e6a0953803c6bebc2e1592
-  languageName: node
-  linkType: hard
-
-"@babel/highlight@npm:^7.14.5, @babel/highlight@npm:^7.16.7":
-  version: 7.16.10
-  resolution: "@babel/highlight@npm:7.16.10"
-  dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.16.7"
-    chalk: "npm:^2.0.0"
-    js-tokens: "npm:^4.0.0"
-  checksum: 10/1f1bdd752a90844f4efc22166a46303fb651ba0fd75a06daba3ebae2575ab3edc1da9827c279872a3aaf305f50a18473c5fa1966752726a2b253065fd4c0745e
-  languageName: node
-  linkType: hard
-
-"@babel/highlight@npm:^7.24.2":
-  version: 7.24.2
-  resolution: "@babel/highlight@npm:7.24.2"
-  dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.22.20"
-    chalk: "npm:^2.4.2"
-    js-tokens: "npm:^4.0.0"
-    picocolors: "npm:^1.0.0"
-  checksum: 10/4555124235f34403bb28f55b1de58edf598491cc181c75f8afc8fe529903cb598cd52fe3bf2faab9bc1f45c299681ef0e44eea7a848bb85c500c5a4fe13f54f6
   languageName: node
   linkType: hard
 
@@ -730,60 +312,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0":
-  version: 7.16.7
-  resolution: "@babel/parser@npm:7.16.7"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.25.0, @babel/parser@npm:^7.25.3":
+  version: 7.25.3
+  resolution: "@babel/parser@npm:7.25.3"
+  dependencies:
+    "@babel/types": "npm:^7.25.2"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 10/dfc7d5d1a2f621e12b1beba94bb7dc3173439dc9f9399b1aad5bafd41b13a5c18a5c496cf8a3ec015c1d6b92a6be291e9d63faf813464360956c68fa725807c3
+  checksum: 10/7bd57e89110bdc9cffe0ef2f2286f1cfb9bbb3aa1d9208c287e0bf6a1eb4cfe6ab33958876ebc59aafcbe3e2381c4449240fc7cc2ff32b79bc9db89cd52fc779
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.14.5, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.7, @babel/parser@npm:^7.17.0":
-  version: 7.17.0
-  resolution: "@babel/parser@npm:7.17.0"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10/4fba51051be55b7d78b272653583f4c0abf049a359a88c25c53ecceb2033da5e8fbc6a3efe933b955035d882c4ea7bb2bc5e481f19f2f0528cc3d008557920fc
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.17.10":
-  version: 7.17.10
-  resolution: "@babel/parser@npm:7.17.10"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10/e2dffa58d2dff56f14f788132fe03999f2d02ecffff1c5e2a59db29ae14840e59c40f16258a89f27e470cb87aef56e78081d65a417c6daa1e31641d564c1496e
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.23.9, @babel/parser@npm:^7.24.8, @babel/parser@npm:^7.25.0":
-  version: 7.25.0
-  resolution: "@babel/parser@npm:7.25.0"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10/1860179256b5e04259a1d567dc43470306757f51c515bedd6fc92dc5f8b4c4a6582c0b1f89a90fd4e981430195b727348d50c890b21c7eb84871248884771aaf
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.24.0, @babel/parser@npm:^7.24.1":
-  version: 7.24.4
-  resolution: "@babel/parser@npm:7.24.4"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10/3742cc5068036287e6395269dce5a2735e6349cdc8d4b53297c75f98c580d7e1c8cb43235623999d151f2ef975d677dbc2c2357573a1855caa71c271bf3046c9
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:^7.25.0":
-  version: 7.25.0
-  resolution: "@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:7.25.0"
+"@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:^7.25.3":
+  version: 7.25.3
+  resolution: "@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:7.25.3"
   dependencies:
     "@babel/helper-plugin-utils": "npm:^7.24.8"
-    "@babel/traverse": "npm:^7.25.0"
+    "@babel/traverse": "npm:^7.25.3"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10/9befa15787d9dd0abba6a84e2c8a40d798241cbe00d186ad453bcf91342fe5dd0f6882a246bb209c9bd5d2f0b914d83850e1dcf99e144a45fe7918538ef40020
+  checksum: 10/9743feb0152f2ac686aaee6dfd41e8ea211989a459d4c2b10b531442f6865057cd1a502515634c25462b155bc58f0710267afed72396780e9b72be25370dd577
   languageName: node
   linkType: hard
 
@@ -953,7 +501,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.24.7":
+"@babel/plugin-syntax-jsx@npm:^7.24.7, @babel/plugin-syntax-jsx@npm:^7.7.2":
   version: 7.24.7
   resolution: "@babel/plugin-syntax-jsx@npm:7.24.7"
   dependencies:
@@ -961,17 +509,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10/a93516ae5b34868ab892a95315027d4e5e38e8bd1cfca6158f2974b0901cbb32bbe64ea10ad5b25f919ddc40c6d8113c4823372909c9c9922170c12b0b1acecb
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-jsx@npm:^7.7.2":
-  version: 7.21.4
-  resolution: "@babel/plugin-syntax-jsx@npm:7.21.4"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.20.2"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10/bb7309402a1d4e155f32aa0cf216e1fa8324d6c4cfd248b03280028a015a10e46b6efd6565f515f8913918a3602b39255999c06046f7d4b8a5106be2165d724a
   languageName: node
   linkType: hard
 
@@ -1063,7 +600,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-typescript@npm:^7.24.7":
+"@babel/plugin-syntax-typescript@npm:^7.24.7, @babel/plugin-syntax-typescript@npm:^7.7.2":
   version: 7.24.7
   resolution: "@babel/plugin-syntax-typescript@npm:7.24.7"
   dependencies:
@@ -1071,17 +608,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10/2518cc06323f5673c93142935879c112fea0ee836dfa9a9ec744fc972fdeaf22a06fe631c23817562aaaddadf64626a4fbba98c300b3e2c828f48f0f1cca0ce0
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-typescript@npm:^7.7.2":
-  version: 7.16.7
-  resolution: "@babel/plugin-syntax-typescript@npm:7.16.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.16.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10/661e636060609ede9a402e22603b01784c21fabb0a637e65f561c8159351fe0130bbc11fdefe31902107885e3332fc34d95eb652ac61d3f61f2d61f5da20609e
   languageName: node
   linkType: hard
 
@@ -1304,7 +830,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-function-name@npm:^7.25.0":
+"@babel/plugin-transform-function-name@npm:^7.25.1":
   version: 7.25.1
   resolution: "@babel/plugin-transform-function-name@npm:7.25.1"
   dependencies:
@@ -1329,14 +855,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-literals@npm:^7.24.7":
-  version: 7.24.7
-  resolution: "@babel/plugin-transform-literals@npm:7.24.7"
+"@babel/plugin-transform-literals@npm:^7.25.2":
+  version: 7.25.2
+  resolution: "@babel/plugin-transform-literals@npm:7.25.2"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.24.7"
+    "@babel/helper-plugin-utils": "npm:^7.24.8"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10/bf341a5a0ffb5129670ac9a14ea53b67bd1d3d0e13173ce7ac2d4184c4b405d33f67df68c59a2e94a895bf80269ec1df82c011d9ddb686f9f08a40c37b881177
+  checksum: 10/d9728625a6d55305610dd37057fe1a3473df4f3789fef693c900516caf8958dfb341394ecf69ce9b60c82c422ad2954491a7e4d4533432fd5df812827443d6e9
   languageName: node
   linkType: hard
 
@@ -1640,8 +1166,8 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-typescript@npm:^7.24.7":
-  version: 7.25.0
-  resolution: "@babel/plugin-transform-typescript@npm:7.25.0"
+  version: 7.25.2
+  resolution: "@babel/plugin-transform-typescript@npm:7.25.2"
   dependencies:
     "@babel/helper-annotate-as-pure": "npm:^7.24.7"
     "@babel/helper-create-class-features-plugin": "npm:^7.25.0"
@@ -1650,7 +1176,7 @@ __metadata:
     "@babel/plugin-syntax-typescript": "npm:^7.24.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10/ae712ab19078d285c02bf5bdf6e4eccd318a30a76f0a6f2bafaea6d86f653580ba1f513a7843155b1511a4999e161eb889e8a09513abc4cbbd847f4a735663e9
+  checksum: 10/50e017ffd131c08661daa22b6c759999bb7a6cdfbf683291ee4bcbea4ae839440b553d2f8896bcf049aca1d267b39f3b09e8336059e919e83149b5ad859671f6
   languageName: node
   linkType: hard
 
@@ -1702,14 +1228,14 @@ __metadata:
   linkType: hard
 
 "@babel/preset-env@npm:^7.25.0":
-  version: 7.25.0
-  resolution: "@babel/preset-env@npm:7.25.0"
+  version: 7.25.3
+  resolution: "@babel/preset-env@npm:7.25.3"
   dependencies:
-    "@babel/compat-data": "npm:^7.25.0"
-    "@babel/helper-compilation-targets": "npm:^7.24.8"
+    "@babel/compat-data": "npm:^7.25.2"
+    "@babel/helper-compilation-targets": "npm:^7.25.2"
     "@babel/helper-plugin-utils": "npm:^7.24.8"
     "@babel/helper-validator-option": "npm:^7.24.8"
-    "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "npm:^7.25.0"
+    "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "npm:^7.25.3"
     "@babel/plugin-bugfix-safari-class-field-initializer-scope": "npm:^7.25.0"
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "npm:^7.25.0"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "npm:^7.24.7"
@@ -1750,9 +1276,9 @@ __metadata:
     "@babel/plugin-transform-exponentiation-operator": "npm:^7.24.7"
     "@babel/plugin-transform-export-namespace-from": "npm:^7.24.7"
     "@babel/plugin-transform-for-of": "npm:^7.24.7"
-    "@babel/plugin-transform-function-name": "npm:^7.25.0"
+    "@babel/plugin-transform-function-name": "npm:^7.25.1"
     "@babel/plugin-transform-json-strings": "npm:^7.24.7"
-    "@babel/plugin-transform-literals": "npm:^7.24.7"
+    "@babel/plugin-transform-literals": "npm:^7.25.2"
     "@babel/plugin-transform-logical-assignment-operators": "npm:^7.24.7"
     "@babel/plugin-transform-member-expression-literals": "npm:^7.24.7"
     "@babel/plugin-transform-modules-amd": "npm:^7.24.7"
@@ -1790,7 +1316,7 @@ __metadata:
     semver: "npm:^6.3.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10/df061ad7e18245a631fc161ba8a1e9c6ec51216e09d373ba5d395bc52c84e48ca7e8b0571328705a0e7daae78738a2e57f265b265f42f0b774e8e277eab31995
+  checksum: 10/293c32dee33f138d22cea0c0e163b6d79ef3860ac269921a438edb4adbfa53976ce2cd3f7a79408c8e52c852b5feda45abdbc986a54e9d9aa0b6680d7a371a58
   languageName: node
   linkType: hard
 
@@ -1845,37 +1371,15 @@ __metadata:
   linkType: hard
 
 "@babel/runtime@npm:^7.8.4":
-  version: 7.12.1
-  resolution: "@babel/runtime@npm:7.12.1"
+  version: 7.25.0
+  resolution: "@babel/runtime@npm:7.25.0"
   dependencies:
-    regenerator-runtime: "npm:^0.13.4"
-  checksum: 10/bcf0c7c9684939ff528c1d0dc627ed79cb1b91722c5b2a89a7a7f18368c190285020adbad4c7dfd0217284481d06e3747bc42e8c4eaf06a707c037b4f5fca346
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 10/6870e9e0e9125075b3aeba49a266f442b10820bfc693019eb6c1785c5a0edbe927e98b8238662cdcdba17842107c040386c3b69f39a0a3b217f9d00ffe685b27
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/template@npm:7.16.7"
-  dependencies:
-    "@babel/code-frame": "npm:^7.16.7"
-    "@babel/parser": "npm:^7.16.7"
-    "@babel/types": "npm:^7.16.7"
-  checksum: 10/f35836a8cd53663508bc5e0b13e7fe3d646197fc1baa74c21d3a713c0c91d39fe6f6c5be8ec1ec139b3d0a00443ab1b8cc7ddf88c6ceb6f9fcf7ea0ae7594eca
-  languageName: node
-  linkType: hard
-
-"@babel/template@npm:^7.22.15":
-  version: 7.24.0
-  resolution: "@babel/template@npm:7.24.0"
-  dependencies:
-    "@babel/code-frame": "npm:^7.23.5"
-    "@babel/parser": "npm:^7.24.0"
-    "@babel/types": "npm:^7.24.0"
-  checksum: 10/8c538338c7de8fac8ada691a5a812bdcbd60bd4a4eb5adae2cc9ee19773e8fb1a724312a00af9e1ce49056ffd3c3475e7287b5668cf6360bfb3f8ac827a06ffe
-  languageName: node
-  linkType: hard
-
-"@babel/template@npm:^7.24.7, @babel/template@npm:^7.25.0":
+"@babel/template@npm:^7.24.7, @babel/template@npm:^7.25.0, @babel/template@npm:^7.3.3":
   version: 7.25.0
   resolution: "@babel/template@npm:7.25.0"
   dependencies:
@@ -1886,125 +1390,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.3.3":
-  version: 7.14.5
-  resolution: "@babel/template@npm:7.14.5"
-  dependencies:
-    "@babel/code-frame": "npm:^7.14.5"
-    "@babel/parser": "npm:^7.14.5"
-    "@babel/types": "npm:^7.14.5"
-  checksum: 10/453210f56e9a3ca5eedd5abd124d50c81ce21a20596391ab3f2b1a8298b37ef39cede3356a988dad032f0fcdc367110ee1155c8b26493e2b0dcc612378177da7
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.16.7, @babel/traverse@npm:^7.17.0, @babel/traverse@npm:^7.17.10, @babel/traverse@npm:^7.17.3, @babel/traverse@npm:^7.17.9":
-  version: 7.24.1
-  resolution: "@babel/traverse@npm:7.24.1"
-  dependencies:
-    "@babel/code-frame": "npm:^7.24.1"
-    "@babel/generator": "npm:^7.24.1"
-    "@babel/helper-environment-visitor": "npm:^7.22.20"
-    "@babel/helper-function-name": "npm:^7.23.0"
-    "@babel/helper-hoist-variables": "npm:^7.22.5"
-    "@babel/helper-split-export-declaration": "npm:^7.22.6"
-    "@babel/parser": "npm:^7.24.1"
-    "@babel/types": "npm:^7.24.0"
-    debug: "npm:^4.3.1"
-    globals: "npm:^11.1.0"
-  checksum: 10/b9b0173c286ef549e179f3725df3c4958069ad79fe5b9840adeb99692eb4a5a08db4e735c0f086aab52e7e08ec711cee9e7c06cb908d8035641d1382172308d3
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.24.7, @babel/traverse@npm:^7.24.8, @babel/traverse@npm:^7.25.0":
-  version: 7.25.0
-  resolution: "@babel/traverse@npm:7.25.0"
+"@babel/traverse@npm:^7.24.7, @babel/traverse@npm:^7.24.8, @babel/traverse@npm:^7.25.0, @babel/traverse@npm:^7.25.1, @babel/traverse@npm:^7.25.2, @babel/traverse@npm:^7.25.3":
+  version: 7.25.3
+  resolution: "@babel/traverse@npm:7.25.3"
   dependencies:
     "@babel/code-frame": "npm:^7.24.7"
     "@babel/generator": "npm:^7.25.0"
-    "@babel/parser": "npm:^7.25.0"
+    "@babel/parser": "npm:^7.25.3"
     "@babel/template": "npm:^7.25.0"
-    "@babel/types": "npm:^7.25.0"
+    "@babel/types": "npm:^7.25.2"
     debug: "npm:^4.3.1"
     globals: "npm:^11.1.0"
-  checksum: 10/0730e91caba2e94e614157c1c8ab11e19fd978938f4103f741e73f4916a910d5db0461e41329424475fda8fe03c2b7936df85d13716e77500f4db95765f02a04
+  checksum: 10/fba34f323e17fa83372fc290bc12413a50e2f780a86c7d8b1875c594b6be2857867804de5d52ab10a78a9cae29e1b09ea15d85ad63671ce97d79c40650282bb9
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.25.1":
-  version: 7.25.1
-  resolution: "@babel/traverse@npm:7.25.1"
-  dependencies:
-    "@babel/code-frame": "npm:^7.24.7"
-    "@babel/generator": "npm:^7.25.0"
-    "@babel/parser": "npm:^7.25.0"
-    "@babel/template": "npm:^7.25.0"
-    "@babel/types": "npm:^7.25.0"
-    debug: "npm:^4.3.1"
-    globals: "npm:^11.1.0"
-  checksum: 10/319397a4d32c76c28dba8d446ed3297df6c910e086ee766fb8d2024051bd1d6fbcb74718035c3d9cfd54c7aaa2f1eb48e404b9caac400fe065657071287f927e
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
-  version: 7.16.8
-  resolution: "@babel/types@npm:7.16.8"
-  dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.16.7"
-    to-fast-properties: "npm:^2.0.0"
-  checksum: 10/3e224411b34c268c74f7dc9ff5d5787cbe259f8f7149bc5c71c376196fc9430f9f6e0f46264d5161eae270c59cb14e31ce0b21699592997b56c88da77188fd75
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.14.5, @babel/types@npm:^7.16.7, @babel/types@npm:^7.17.0":
-  version: 7.17.0
-  resolution: "@babel/types@npm:7.17.0"
-  dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.16.7"
-    to-fast-properties: "npm:^2.0.0"
-  checksum: 10/535ccef360d0c74e2bb685050f3a45e6ab30f66c740bbdd0858148ed502043f1ae2006a9d0269ac3b7356b690091ae313efd912e408bc0198d80a14b2a6f1537
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.17.10":
-  version: 7.17.10
-  resolution: "@babel/types@npm:7.17.10"
-  dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.16.7"
-    to-fast-properties: "npm:^2.0.0"
-  checksum: 10/e128cc776b7c7e48884c0c3665f475cb8432a4404f2fc10ab7edc831998ed6ec423411191171a72a1e08058c7d8faa5b535b5cc9c3bb2677fe35ac3505792045
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.18.6, @babel/types@npm:^7.8.3":
-  version: 7.22.4
-  resolution: "@babel/types@npm:7.22.4"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.21.5"
-    "@babel/helper-validator-identifier": "npm:^7.19.1"
-    to-fast-properties: "npm:^2.0.0"
-  checksum: 10/e614d94f96f45964a42cf12aff2c84e5500045b6c20dd054e38fc39be9e0a6fa64b7241bff55a9d01e02a9656687bfa2bc44fb9c95380f7c5b228126ade62b1b
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.24.0":
-  version: 7.24.0
-  resolution: "@babel/types@npm:7.24.0"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.23.4"
-    "@babel/helper-validator-identifier": "npm:^7.22.20"
-    to-fast-properties: "npm:^2.0.0"
-  checksum: 10/a0b4875ce2e132f9daff0d5b27c7f4c4fcc97f2b084bdc5834e92c9d32592778489029e65d99d00c406da612d87b72d7a236c0afccaa1435c028d0c94c9b6da4
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.24.7, @babel/types@npm:^7.24.8, @babel/types@npm:^7.24.9, @babel/types@npm:^7.25.0":
-  version: 7.25.0
-  resolution: "@babel/types@npm:7.25.0"
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.24.7, @babel/types@npm:^7.24.8, @babel/types@npm:^7.25.0, @babel/types@npm:^7.25.2, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
+  version: 7.25.2
+  resolution: "@babel/types@npm:7.25.2"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.24.8"
     "@babel/helper-validator-identifier": "npm:^7.24.7"
     to-fast-properties: "npm:^2.0.0"
-  checksum: 10/07bd6079e64a8c4038367188390b7e51403fe8b43ff7cf651154ce3202c733cda6616bab9f866b89a2b740b640b9fbab37c5b5c94cc18ec9f9b348dadfa73dff
+  checksum: 10/ccf5399db1dcd6dd87b84a6f7bc8dd241e04a326f4f038c973c26ccb69cd360c8f2276603f584c58fd94da95229313060b27baceb0d9b18a435742d3f616afd1
   languageName: node
   linkType: hard
 
@@ -2113,7 +1521,7 @@ __metadata:
     "@exercism/eslint-config-typescript": "npm:^0.7.1"
     "@jest/globals": "npm:^29.7.0"
     "@tsconfig/node20": "npm:^20.1.4"
-    "@types/node": "npm:~22.0.0"
+    "@types/node": "npm:~22.0.2"
     babel-jest: "npm:^29.7.0"
     chalk: "npm:^5.3.0"
     core-js: "npm:~3.37.1"
@@ -2130,13 +1538,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gar/promisify@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@gar/promisify@npm:1.1.3"
-  checksum: 10/052dd232140fa60e81588000cbe729a40146579b361f1070bce63e2a761388a22a16d00beeffc504bd3601cb8e055c57b21a185448b3ed550cf50716f4fd442e
-  languageName: node
-  linkType: hard
-
 "@humanwhocodes/module-importer@npm:^1.0.1":
   version: 1.0.1
   resolution: "@humanwhocodes/module-importer@npm:1.0.1"
@@ -2148,6 +1549,20 @@ __metadata:
   version: 0.3.0
   resolution: "@humanwhocodes/retry@npm:0.3.0"
   checksum: 10/e574bab58680867414e225c9002e9a97eb396f85871c180fbb1a9bcdf9ded4b4de0b327f7d0c43b775873362b7c92956d4b322e8bc4b90be56077524341f04b2
+  languageName: node
+  linkType: hard
+
+"@isaacs/cliui@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "@isaacs/cliui@npm:8.0.2"
+  dependencies:
+    string-width: "npm:^5.1.2"
+    string-width-cjs: "npm:string-width@^4.2.0"
+    strip-ansi: "npm:^7.0.1"
+    strip-ansi-cjs: "npm:strip-ansi@^6.0.1"
+    wrap-ansi: "npm:^8.1.0"
+    wrap-ansi-cjs: "npm:wrap-ansi@^7.0.0"
+  checksum: 10/e9ed5fd27c3aec1095e3a16e0c0cf148d1fee55a38665c35f7b3f86a9b5d00d042ddaabc98e8a1cb7463b9378c15f22a94eb35e99469c201453eb8375191f243
   languageName: node
   linkType: hard
 
@@ -2164,14 +1579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@istanbuljs/schema@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "@istanbuljs/schema@npm:0.1.2"
-  checksum: 10/e4a7fffc72fb2cfe2edfee8a09f68b2da18b1ab328a29d8be2933681f9e36103f0b083a5ae07129f4de26296eb7c2a1cc144cfea6cdb47f871a69766947144d3
-  languageName: node
-  linkType: hard
-
-"@istanbuljs/schema@npm:^0.1.3":
+"@istanbuljs/schema@npm:^0.1.2, @istanbuljs/schema@npm:^0.1.3":
   version: 0.1.3
   resolution: "@istanbuljs/schema@npm:0.1.3"
   checksum: 10/a9b1e49acdf5efc2f5b2359f2df7f90c5c725f2656f16099e8b2cd3a000619ecca9fc48cf693ba789cf0fd989f6e0df6a22bc05574be4223ecdbb7997d04384b
@@ -2408,27 +1816,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.1.0":
-  version: 0.1.1
-  resolution: "@jridgewell/gen-mapping@npm:0.1.1"
-  dependencies:
-    "@jridgewell/set-array": "npm:^1.0.0"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
-  checksum: 10/ba76fae1d8ea52b181474518c705a8eac36405dfc836fb07e9c25730a84d29e05fd6d954f121057742639f3128a24ea45d205c9c989efd464d1114671c19fa6c
-  languageName: node
-  linkType: hard
-
-"@jridgewell/gen-mapping@npm:^0.3.0":
-  version: 0.3.3
-  resolution: "@jridgewell/gen-mapping@npm:0.3.3"
-  dependencies:
-    "@jridgewell/set-array": "npm:^1.0.1"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
-    "@jridgewell/trace-mapping": "npm:^0.3.9"
-  checksum: 10/072ace159c39ab85944bdabe017c3de15c5e046a4a4a772045b00ff05e2ebdcfa3840b88ae27e897d473eb4d4845b37be3c78e28910c779f5aeeeae2fb7f0cc2
-  languageName: node
-  linkType: hard
-
 "@jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.5
   resolution: "@jridgewell/gen-mapping@npm:0.3.5"
@@ -2440,38 +1827,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:3.1.0":
-  version: 3.1.0
-  resolution: "@jridgewell/resolve-uri@npm:3.1.0"
-  checksum: 10/320ceb37af56953757b28e5b90c34556157676d41e3d0a3ff88769274d62373582bb0f0276a4f2d29c3f4fdd55b82b8be5731f52d391ad2ecae9b321ee1c742d
-  languageName: node
-  linkType: hard
-
-"@jridgewell/resolve-uri@npm:^3.0.3":
-  version: 3.0.5
-  resolution: "@jridgewell/resolve-uri@npm:3.0.5"
-  checksum: 10/66da0c14dfaebd3481ac363306eefa45aca6779f8635df7337b97c18873853a7e2946d79104fad3e2ab832fe438ebabcaa2091e55e069a81b35001fa6738f532
-  languageName: node
-  linkType: hard
-
 "@jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 10/97106439d750a409c22c8bff822d648f6a71f3aa9bc8e5129efdc36343cd3096ddc4eeb1c62d2fe48e9bdd4db37b05d4646a17114ecebd3bbcacfa2de51c3c1d
-  languageName: node
-  linkType: hard
-
-"@jridgewell/set-array@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "@jridgewell/set-array@npm:1.1.0"
-  checksum: 10/86ddd72ce7d2f7756dfb69804b35d0e760a85dcef30ed72e8610bf2c5e843f8878d977a0c77c4fdfa6a0e3d5b18e5bde4a1f1dd73fd2db06b200c998e9b5a6c5
-  languageName: node
-  linkType: hard
-
-"@jridgewell/set-array@npm:^1.0.1":
-  version: 1.1.2
-  resolution: "@jridgewell/set-array@npm:1.1.2"
-  checksum: 10/69a84d5980385f396ff60a175f7177af0b8da4ddb81824cb7016a9ef914eee9806c72b6b65942003c63f7983d4f39a5c6c27185bbca88eb4690b62075602e28e
   languageName: node
   linkType: hard
 
@@ -2482,74 +1841,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:1.4.14":
-  version: 1.4.14
-  resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
-  checksum: 10/26e768fae6045481a983e48aa23d8fcd23af5da70ebd74b0649000e815e7fbb01ea2bc088c9176b3fffeb9bec02184e58f46125ef3320b30eaa1f4094cfefa38
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14":
+  version: 1.5.0
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
+  checksum: 10/4ed6123217569a1484419ac53f6ea0d9f3b57e5b57ab30d7c267bdb27792a27eb0e4b08e84a2680aa55cc2f2b411ffd6ec3db01c44fdc6dc43aca4b55f8374fd
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10":
-  version: 1.4.11
-  resolution: "@jridgewell/sourcemap-codec@npm:1.4.11"
-  checksum: 10/591ca7f7884a51643e713b1b623c6c7d751bdc78d61b6cda1dcf7de1287e7f0530514c3f2c7d443273ddc8687637a95cd19f5d8986b32e2349d0f7310623df40
-  languageName: node
-  linkType: hard
-
-"@jridgewell/sourcemap-codec@npm:^1.4.14":
-  version: 1.4.15
-  resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
-  checksum: 10/89960ac087781b961ad918978975bcdf2051cd1741880469783c42de64239703eab9db5230d776d8e6a09d73bb5e4cb964e07d93ee6e2e7aea5a7d726e865c09
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:^0.3.0":
-  version: 0.3.4
-  resolution: "@jridgewell/trace-mapping@npm:0.3.4"
-  dependencies:
-    "@jridgewell/resolve-uri": "npm:^3.0.3"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
-  checksum: 10/2f47f796000ddb956b8fc43b60515594adfba867747d982da83dac0790147027902486ebc997e78944ca7531b0fc091ce8a105f9a863fba3fffa79b1a976fee6
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:^0.3.12":
-  version: 0.3.18
-  resolution: "@jridgewell/trace-mapping@npm:0.3.18"
-  dependencies:
-    "@jridgewell/resolve-uri": "npm:3.1.0"
-    "@jridgewell/sourcemap-codec": "npm:1.4.14"
-  checksum: 10/f4fabdddf82398a797bcdbb51c574cd69b383db041a6cae1a6a91478681d6aab340c01af655cfd8c6e01cde97f63436a1445f08297cdd33587621cf05ffa0d55
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
   version: 0.3.25
   resolution: "@jridgewell/trace-mapping@npm:0.3.25"
   dependencies:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10/dced32160a44b49d531b80a4a2159dceab6b3ddf0c8e95a0deae4b0e894b172defa63d5ac52a19c2068e1fe7d31ea4ba931fbeec103233ecb4208953967120fc
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:^0.3.9":
-  version: 0.3.9
-  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
-  dependencies:
-    "@jridgewell/resolve-uri": "npm:^3.0.3"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
-  checksum: 10/83deafb8e7a5ca98993c2c6eeaa93c270f6f647a4c0dc00deb38c9cf9b2d3b7bf15e8839540155247ef034a052c0ec4466f980bf0c9e2ab63b97d16c0cedd3ff
-  languageName: node
-  linkType: hard
-
-"@nodelib/fs.scandir@npm:2.1.3":
-  version: 2.1.3
-  resolution: "@nodelib/fs.scandir@npm:2.1.3"
-  dependencies:
-    "@nodelib/fs.stat": "npm:2.0.3"
-    run-parallel: "npm:^1.1.9"
-  checksum: 10/7a37ebcfadf6fd5c1aafefd7f6759d341be42cb7e1dd53455d0bfc2f730e2449bd71ba299b38ca0200f16af1bdf3ebc45bcb2972bf91df17e49acf433537bc8e
   languageName: node
   linkType: hard
 
@@ -2563,31 +1868,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodelib/fs.stat@npm:2.0.3, @nodelib/fs.stat@npm:^2.0.2":
-  version: 2.0.3
-  resolution: "@nodelib/fs.stat@npm:2.0.3"
-  checksum: 10/c883a168a7bf1931f6818fa23691c7ed0f9129149f91a0926a86a7aee4f0febc9df479d898ef2b2a6de5533824ede506cfbec076e8fa17bfd82c76d2001cd4a0
-  languageName: node
-  linkType: hard
-
-"@nodelib/fs.stat@npm:2.0.5":
+"@nodelib/fs.stat@npm:2.0.5, @nodelib/fs.stat@npm:^2.0.2":
   version: 2.0.5
   resolution: "@nodelib/fs.stat@npm:2.0.5"
   checksum: 10/012480b5ca9d97bff9261571dbbec7bbc6033f69cc92908bc1ecfad0792361a5a1994bc48674b9ef76419d056a03efadfce5a6cf6dbc0a36559571a7a483f6f0
   languageName: node
   linkType: hard
 
-"@nodelib/fs.walk@npm:^1.2.3":
-  version: 1.2.4
-  resolution: "@nodelib/fs.walk@npm:1.2.4"
-  dependencies:
-    "@nodelib/fs.scandir": "npm:2.1.3"
-    fastq: "npm:^1.6.0"
-  checksum: 10/31b13e243cc7f8656e936be684f16f81ede62c3be5968f832ca9dab385db0c3bcd537aeb139bdec4cdb6973ba55035069978397a0d08317b7023e53128e915bd
-  languageName: node
-  linkType: hard
-
-"@nodelib/fs.walk@npm:^1.2.8":
+"@nodelib/fs.walk@npm:^1.2.3, @nodelib/fs.walk@npm:^1.2.8":
   version: 1.2.8
   resolution: "@nodelib/fs.walk@npm:1.2.8"
   dependencies:
@@ -2597,23 +1885,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/fs@npm:^2.1.0":
-  version: 2.1.2
-  resolution: "@npmcli/fs@npm:2.1.2"
+"@npmcli/agent@npm:^2.0.0":
+  version: 2.2.2
+  resolution: "@npmcli/agent@npm:2.2.2"
   dependencies:
-    "@gar/promisify": "npm:^1.1.3"
-    semver: "npm:^7.3.5"
-  checksum: 10/c5d4dfee80de2236e1e4ed595d17e217aada72ebd8215183fc46096fa010f583dd2aaaa486758de7cc0b89440dbc31cfe8b276269d75d47af35c716e896f78ec
+    agent-base: "npm:^7.1.0"
+    http-proxy-agent: "npm:^7.0.0"
+    https-proxy-agent: "npm:^7.0.1"
+    lru-cache: "npm:^10.0.1"
+    socks-proxy-agent: "npm:^8.0.3"
+  checksum: 10/96fc0036b101bae5032dc2a4cd832efb815ce9b33f9ee2f29909ee49d96a0026b3565f73c507a69eb8603f5cb32e0ae45a70cab1e2655990a4e06ae99f7f572a
   languageName: node
   linkType: hard
 
-"@npmcli/move-file@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "@npmcli/move-file@npm:2.0.1"
+"@npmcli/fs@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "@npmcli/fs@npm:3.1.1"
   dependencies:
-    mkdirp: "npm:^1.0.4"
-    rimraf: "npm:^3.0.2"
-  checksum: 10/52dc02259d98da517fae4cb3a0a3850227bdae4939dda1980b788a7670636ca2b4a01b58df03dd5f65c1e3cb70c50fa8ce5762b582b3f499ec30ee5ce1fd9380
+    semver: "npm:^7.3.5"
+  checksum: 10/1e0e04087049b24b38bc0b30d87a9388ee3ca1d3fdfc347c2f77d84fcfe6a51f250bc57ba2c1f614d7e4285c6c62bf8c769bc19aa0949ea39e5b043ee023b0bd
+  languageName: node
+  linkType: hard
+
+"@pkgjs/parseargs@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@pkgjs/parseargs@npm:0.11.0"
+  checksum: 10/115e8ceeec6bc69dff2048b35c0ab4f8bbee12d8bb6c1f4af758604586d802b6e669dcb02dda61d078de42c2b4ddce41b3d9e726d7daa6b4b850f4adbf7333ff
   languageName: node
   linkType: hard
 
@@ -2625,26 +1922,26 @@ __metadata:
   linkType: hard
 
 "@sinonjs/commons@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@sinonjs/commons@npm:3.0.0"
+  version: 3.0.1
+  resolution: "@sinonjs/commons@npm:3.0.1"
   dependencies:
     type-detect: "npm:4.0.8"
-  checksum: 10/086720ae0bc370829322df32612205141cdd44e592a8a9ca97197571f8f970352ea39d3bda75b347c43789013ddab36b34b59e40380a49bdae1c2df3aa85fe4f
+  checksum: 10/a0af217ba7044426c78df52c23cedede6daf377586f3ac58857c565769358ab1f44ebf95ba04bbe38814fba6e316ca6f02870a009328294fc2c555d0f85a7117
   languageName: node
   linkType: hard
 
 "@sinonjs/fake-timers@npm:^10.0.2":
-  version: 10.2.0
-  resolution: "@sinonjs/fake-timers@npm:10.2.0"
+  version: 10.3.0
+  resolution: "@sinonjs/fake-timers@npm:10.3.0"
   dependencies:
     "@sinonjs/commons": "npm:^3.0.0"
-  checksum: 10/da08032b67a090b8844b2a2be7b299da1f6f48fa0b86f74e5add9d545bb8cc23aed2ed8d0cde43fca5e486b29004e31f65cbe205fd892213d5ada0c1ce9005c1
+  checksum: 10/78155c7bd866a85df85e22028e046b8d46cf3e840f72260954f5e3ed5bd97d66c595524305a6841ffb3f681a08f6e5cef572a2cce5442a8a232dc29fb409b83e
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin-js@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@stylistic/eslint-plugin-js@npm:2.4.0"
+"@stylistic/eslint-plugin-js@npm:2.6.0":
+  version: 2.6.0
+  resolution: "@stylistic/eslint-plugin-js@npm:2.6.0"
   dependencies:
     "@types/eslint": "npm:^9.6.0"
     acorn: "npm:^8.12.1"
@@ -2652,27 +1949,20 @@ __metadata:
     espree: "npm:^10.1.0"
   peerDependencies:
     eslint: ">=8.40.0"
-  checksum: 10/9efccd6c59404f8ec2cc93261380df1c60126ee1f7972456e3f1501ab1d5387f93ea8a83d2e8910c9788cfc262837af85bd4dabf6052474afa5bf6a0e9cd1016
+  checksum: 10/95e7604769cc9a914c50ac52dc9b136c8e66cb2f183b64acf4571b91dc272e2170bfd7293d937a60a2a5c5892f617a233eeca009af32263e305f53b8a14077d3
   languageName: node
   linkType: hard
 
 "@stylistic/eslint-plugin-ts@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "@stylistic/eslint-plugin-ts@npm:2.4.0"
+  version: 2.6.0
+  resolution: "@stylistic/eslint-plugin-ts@npm:2.6.0"
   dependencies:
-    "@stylistic/eslint-plugin-js": "npm:2.4.0"
+    "@stylistic/eslint-plugin-js": "npm:2.6.0"
     "@types/eslint": "npm:^9.6.0"
-    "@typescript-eslint/utils": "npm:^7.17.0"
+    "@typescript-eslint/utils": "npm:^8.0.0"
   peerDependencies:
     eslint: ">=8.40.0"
-  checksum: 10/c613fe011c88cba84217afcb3016f631eaec556a4ac464b7c48312067d37e10875377a369b2477f3b7a0e3aa0edb5e17ce7d39ab86bc3928f0fb5b738125e878
-  languageName: node
-  linkType: hard
-
-"@tootallnate/once@npm:2":
-  version: 2.0.0
-  resolution: "@tootallnate/once@npm:2.0.0"
-  checksum: 10/ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
+  checksum: 10/ca88e326b9c3f107191aec49d299e0bbb5c29ad1703c00b0ada22c7457a331b8c6f5a3431b06918b006a6bf1bd30e36633c80ca61ce9f21ee23571b886849122
   languageName: node
   linkType: hard
 
@@ -2684,43 +1974,43 @@ __metadata:
   linkType: hard
 
 "@types/babel__core@npm:^7.1.14":
-  version: 7.1.18
-  resolution: "@types/babel__core@npm:7.1.18"
+  version: 7.20.5
+  resolution: "@types/babel__core@npm:7.20.5"
   dependencies:
-    "@babel/parser": "npm:^7.1.0"
-    "@babel/types": "npm:^7.0.0"
+    "@babel/parser": "npm:^7.20.7"
+    "@babel/types": "npm:^7.20.7"
     "@types/babel__generator": "npm:*"
     "@types/babel__template": "npm:*"
     "@types/babel__traverse": "npm:*"
-  checksum: 10/7921d75d42eed69b9ba9fc282490216ab77a6bcf93681ed8a9da77f9ba2912c973667e9d706e6e012673e713b36c4e3654ecd25057736346e6c794f25d309a87
+  checksum: 10/c32838d280b5ab59d62557f9e331d3831f8e547ee10b4f85cb78753d97d521270cebfc73ce501e9fb27fe71884d1ba75e18658692c2f4117543f0fc4e3e118b3
   languageName: node
   linkType: hard
 
 "@types/babel__generator@npm:*":
-  version: 7.6.2
-  resolution: "@types/babel__generator@npm:7.6.2"
+  version: 7.6.8
+  resolution: "@types/babel__generator@npm:7.6.8"
   dependencies:
     "@babel/types": "npm:^7.0.0"
-  checksum: 10/e1e1dac9c63c13a416224723b3f28e6618ee3c879906845f712311e954a77b8d1a4d757625def9c622897a9c66d69f28dd81aa600dddf73ac3858b028c4043b1
+  checksum: 10/b53c215e9074c69d212402990b0ca8fa57595d09e10d94bda3130aa22b55d796e50449199867879e4ea0ee968f3a2099e009cfb21a726a53324483abbf25cd30
   languageName: node
   linkType: hard
 
 "@types/babel__template@npm:*":
-  version: 7.0.3
-  resolution: "@types/babel__template@npm:7.0.3"
+  version: 7.4.4
+  resolution: "@types/babel__template@npm:7.4.4"
   dependencies:
     "@babel/parser": "npm:^7.1.0"
     "@babel/types": "npm:^7.0.0"
-  checksum: 10/f434cc29bb56d57ae62122f77906e911883847ece6d3ac0c645f102fa8fb70c161cf2d06c359a462b520da4b64c63defc37c30842b244bc681e5ece0f3e9c188
+  checksum: 10/d7a02d2a9b67e822694d8e6a7ddb8f2b71a1d6962dfd266554d2513eefbb205b33ca71a0d163b1caea3981ccf849211f9964d8bd0727124d18ace45aa6c9ae29
   languageName: node
   linkType: hard
 
 "@types/babel__traverse@npm:*, @types/babel__traverse@npm:^7.0.6":
-  version: 7.0.15
-  resolution: "@types/babel__traverse@npm:7.0.15"
+  version: 7.20.6
+  resolution: "@types/babel__traverse@npm:7.20.6"
   dependencies:
-    "@babel/types": "npm:^7.3.0"
-  checksum: 10/26fb160d75e8e4de11c13b479390639056bb34f422b2a8ab234021d9f3d7425ed1cc9b11f4dc61478eeb940f98baa736aa347811e22641a490a8960a8862cc39
+    "@babel/types": "npm:^7.20.7"
+  checksum: 10/63d13a3789aa1e783b87a8b03d9fb2c2c90078de7782422feff1631b8c2a25db626e63a63ac5a1465d47359201c73069dacb4b52149d17c568187625da3064ae
   languageName: node
   linkType: hard
 
@@ -2742,36 +2032,36 @@ __metadata:
   linkType: hard
 
 "@types/graceful-fs@npm:^4.1.3":
-  version: 4.1.5
-  resolution: "@types/graceful-fs@npm:4.1.5"
+  version: 4.1.9
+  resolution: "@types/graceful-fs@npm:4.1.9"
   dependencies:
     "@types/node": "npm:*"
-  checksum: 10/d076bb61f45d0fc42dee496ef8b1c2f8742e15d5e47e90e20d0243386e426c04d4efd408a48875ab432f7960b4ce3414db20ed0fbbfc7bcc89d84e574f6e045a
+  checksum: 10/79d746a8f053954bba36bd3d94a90c78de995d126289d656fb3271dd9f1229d33f678da04d10bce6be440494a5a73438e2e363e92802d16b8315b051036c5256
   languageName: node
   linkType: hard
 
 "@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
-  version: 2.0.3
-  resolution: "@types/istanbul-lib-coverage@npm:2.0.3"
-  checksum: 10/0650cba4be8f464bee89b9de0b71a5ea3b5cc676ce24e1196b5d6a51542ce9e613ae4549bf19756bb33dbbbb32b47931040266100062bfb197c597d73e341eb0
+  version: 2.0.6
+  resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
+  checksum: 10/3feac423fd3e5449485afac999dcfcb3d44a37c830af898b689fadc65d26526460bedb889db278e0d4d815a670331796494d073a10ee6e3a6526301fe7415778
   languageName: node
   linkType: hard
 
 "@types/istanbul-lib-report@npm:*":
-  version: 3.0.0
-  resolution: "@types/istanbul-lib-report@npm:3.0.0"
+  version: 3.0.3
+  resolution: "@types/istanbul-lib-report@npm:3.0.3"
   dependencies:
     "@types/istanbul-lib-coverage": "npm:*"
-  checksum: 10/f121dcac8a6b8184f3cab97286d8d519f1937fa8620ada5dbc43b699d602b8be289e4a4bccbd6ee1aade6869d3c9fb68bf04c6fdca8c5b0c4e7e314c31c7900a
+  checksum: 10/b91e9b60f865ff08cb35667a427b70f6c2c63e88105eadd29a112582942af47ed99c60610180aa8dcc22382fa405033f141c119c69b95db78c4c709fbadfeeb4
   languageName: node
   linkType: hard
 
 "@types/istanbul-reports@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@types/istanbul-reports@npm:3.0.0"
+  version: 3.0.4
+  resolution: "@types/istanbul-reports@npm:3.0.4"
   dependencies:
     "@types/istanbul-lib-report": "npm:*"
-  checksum: 10/286a18cff19c4dac4321b9ea406a3560faf577fb2a4df5abf9d577fa81ba831c9baa7d40d03f1daf7fe613d468546b731c00b844b72fad9834c583311a35bb7b
+  checksum: 10/93eb18835770b3431f68ae9ac1ca91741ab85f7606f310a34b3586b5a34450ec038c3eed7ab19266635499594de52ff73723a54a72a75b9f7d6a956f01edee95
   languageName: node
   linkType: hard
 
@@ -2782,65 +2072,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 16.11.27
-  resolution: "@types/node@npm:16.11.27"
-  checksum: 10/f596c7440efb0e754a492599461f596eab1ad7a870ff52feafaab4ffa3a2c18a46532163244d4815778d09cb2e376b0e23b9d3b4bee9d237adecb4f9419d2f83
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:~22.0.0":
-  version: 22.0.0
-  resolution: "@types/node@npm:22.0.0"
+"@types/node@npm:*, @types/node@npm:~22.0.2":
+  version: 22.0.2
+  resolution: "@types/node@npm:22.0.2"
   dependencies:
     undici-types: "npm:~6.11.1"
-  checksum: 10/7142a13ef1f884fde38f1e1499cbebcfe72755e8cb8657c4cb1ba1c2c91a3ae8656a72eb6e0a7d8189b0124c23c30e7c115324375d9c593435166da7a292e80e
+  checksum: 10/7f5937f22d5171df6d1764b838b64f03fd2686e0ebee15bb64eb609ee5280cfd8cbbb78efdf163bb49eee11c77de461ef8b85e2781e508d231777390ddf0e8ec
   languageName: node
   linkType: hard
 
 "@types/stack-utils@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@types/stack-utils@npm:2.0.0"
-  checksum: 10/b3fbae25b073116977ecb5c67d22f14567b51a7792403b0bf46e5de8f29bde3bd4ec1626afb22065495ca7f1c699c8bd66720050c94b8f8f9bcefbee79d161fd
+  version: 2.0.3
+  resolution: "@types/stack-utils@npm:2.0.3"
+  checksum: 10/72576cc1522090fe497337c2b99d9838e320659ac57fa5560fcbdcbafcf5d0216c6b3a0a8a4ee4fdb3b1f5e3420aa4f6223ab57b82fef3578bec3206425c6cf5
   languageName: node
   linkType: hard
 
 "@types/yargs-parser@npm:*":
-  version: 15.0.0
-  resolution: "@types/yargs-parser@npm:15.0.0"
-  checksum: 10/333ab73a1f9c82c64b2fac2441558e58f062fbe7affc35bb53b8e755b62cdd32b1bbc6f4da23773887a2189bf04395e2a8c710df344df4cd578993aeefe98053
+  version: 21.0.3
+  resolution: "@types/yargs-parser@npm:21.0.3"
+  checksum: 10/a794eb750e8ebc6273a51b12a0002de41343ffe46befef460bdbb57262d187fdf608bc6615b7b11c462c63c3ceb70abe2564c8dd8ee0f7628f38a314f74a9b9b
   languageName: node
   linkType: hard
 
 "@types/yargs@npm:^17.0.8":
-  version: 17.0.10
-  resolution: "@types/yargs@npm:17.0.10"
+  version: 17.0.32
+  resolution: "@types/yargs@npm:17.0.32"
   dependencies:
     "@types/yargs-parser": "npm:*"
-  checksum: 10/cfe94e8ba50364e08d7b3ecb10a7c153762d0e56c571079538bb06b306638d1045e395fc5a745b94519e73798779c761fa386ec13c82306a62349f64d7b9eec1
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/eslint-plugin@npm:7.17.0":
-  version: 7.17.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:7.17.0"
-  dependencies:
-    "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:7.17.0"
-    "@typescript-eslint/type-utils": "npm:7.17.0"
-    "@typescript-eslint/utils": "npm:7.17.0"
-    "@typescript-eslint/visitor-keys": "npm:7.17.0"
-    graphemer: "npm:^1.4.0"
-    ignore: "npm:^5.3.1"
-    natural-compare: "npm:^1.4.0"
-    ts-api-utils: "npm:^1.3.0"
-  peerDependencies:
-    "@typescript-eslint/parser": ^7.0.0
-    eslint: ^8.56.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/f3caba81b7ea4d1b4b097b3de1c51054424ad3d5e37f7af7df64f1c29b6448c535b61e0956f76bfa450b38917923f919a9bab081224c2b5577596caffa6e288a
+  checksum: 10/1e2b2673847011ce43607df690d392f137d95a2d6ea85aa319403eadda2ef4277365efd4982354d8843f2611ef3846c88599660aaeb537fa9ccddae83c2a89de
   languageName: node
   linkType: hard
 
@@ -2867,24 +2127,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:7.17.0":
-  version: 7.17.0
-  resolution: "@typescript-eslint/parser@npm:7.17.0"
-  dependencies:
-    "@typescript-eslint/scope-manager": "npm:7.17.0"
-    "@typescript-eslint/types": "npm:7.17.0"
-    "@typescript-eslint/typescript-estree": "npm:7.17.0"
-    "@typescript-eslint/visitor-keys": "npm:7.17.0"
-    debug: "npm:^4.3.4"
-  peerDependencies:
-    eslint: ^8.56.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/91971e5d95fec798a456ec72d9d67c28eee72d0d1c52e682dbff2eef134e149799f69324ea8d42bd2cfa290eec763073b26fb343ce0632e4fa64c3b8a854d124
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/parser@npm:7.18.0":
   version: 7.18.0
   resolution: "@typescript-eslint/parser@npm:7.18.0"
@@ -2903,16 +2145,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:7.17.0":
-  version: 7.17.0
-  resolution: "@typescript-eslint/scope-manager@npm:7.17.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:7.17.0"
-    "@typescript-eslint/visitor-keys": "npm:7.17.0"
-  checksum: 10/aec72538a92d8a82ca39f60c34b0d0e00f2f8fb74f584aee90b6d1ef28f30a415b507f28aa27a536898992ad4b9b5af58671c743cd50439b21e67bee03a59c88
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:7.18.0":
   version: 7.18.0
   resolution: "@typescript-eslint/scope-manager@npm:7.18.0"
@@ -2923,20 +2155,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:7.17.0":
-  version: 7.17.0
-  resolution: "@typescript-eslint/type-utils@npm:7.17.0"
+"@typescript-eslint/scope-manager@npm:8.0.0":
+  version: 8.0.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.0.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:7.17.0"
-    "@typescript-eslint/utils": "npm:7.17.0"
-    debug: "npm:^4.3.4"
-    ts-api-utils: "npm:^1.3.0"
-  peerDependencies:
-    eslint: ^8.56.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/1405c626cd59a1fb29b897d22dce0b2f5b793e5d1cba228a119e58e7392c385c9131c332e744888b7d6ad41eee0abbd8099651664cafaed24229da2cd768e032
+    "@typescript-eslint/types": "npm:8.0.0"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0"
+  checksum: 10/444dbc156d9d6d2aa4f82e35ab171aed85d1818c5adf70f955f69d6d0591d9a0668f645d38bf5b759098849aa4114340ca128a673be5525a94fba9a048751d0c
   languageName: node
   linkType: hard
 
@@ -2957,13 +2182,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:7.17.0":
-  version: 7.17.0
-  resolution: "@typescript-eslint/types@npm:7.17.0"
-  checksum: 10/92e571f794f51a1f110714a9de661f9a76781c8c3e53d8fe025a88be947ae30d1c18964083467db31001ce7910f1a1459b8f6b039c270bdb6d1de47eba5dfa7f
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/types@npm:7.18.0":
   version: 7.18.0
   resolution: "@typescript-eslint/types@npm:7.18.0"
@@ -2971,22 +2189,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:7.17.0":
-  version: 7.17.0
-  resolution: "@typescript-eslint/typescript-estree@npm:7.17.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:7.17.0"
-    "@typescript-eslint/visitor-keys": "npm:7.17.0"
-    debug: "npm:^4.3.4"
-    globby: "npm:^11.1.0"
-    is-glob: "npm:^4.0.3"
-    minimatch: "npm:^9.0.4"
-    semver: "npm:^7.6.0"
-    ts-api-utils: "npm:^1.3.0"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/419c4ad3b470ea4d654c414bbc66269ba7a6504e10bf2a2a87f9214aad4358b670f60e89ae7e4b2a24fa7c0c4542ebdd3711b8964917c026a5eef27d861e23fb
+"@typescript-eslint/types@npm:8.0.0":
+  version: 8.0.0
+  resolution: "@typescript-eslint/types@npm:8.0.0"
+  checksum: 10/e28e79d8b7acfa42c90781fa63e90e56807ae018a0a92fc71c8e441d2bb3a250527c9d44ff6450ff1d47ceed0c3df28de6599f97f6c4c65ac554088867fc3517
   languageName: node
   linkType: hard
 
@@ -3009,21 +2215,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:7.17.0, @typescript-eslint/utils@npm:^6.0.0 || ^7.0.0, @typescript-eslint/utils@npm:^7.17.0":
-  version: 7.17.0
-  resolution: "@typescript-eslint/utils@npm:7.17.0"
+"@typescript-eslint/typescript-estree@npm:8.0.0":
+  version: 8.0.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.0.0"
   dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:7.17.0"
-    "@typescript-eslint/types": "npm:7.17.0"
-    "@typescript-eslint/typescript-estree": "npm:7.17.0"
-  peerDependencies:
-    eslint: ^8.56.0
-  checksum: 10/44d6bfcda4b03a7bec82939dd975579f40705cf4128e40f747bf96b81e8fae0c384434999334a9ac42990e2864266c8067ca0e4b27d736ce2f6b8667115f7a1d
+    "@typescript-eslint/types": "npm:8.0.0"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0"
+    debug: "npm:^4.3.4"
+    globby: "npm:^11.1.0"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^1.3.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/99a80fb43d1e9cbd49a3dfdd264e7e361ffd4e19970d2b04b86a551fc730cc4f19202c3323d0d6bbfd7ce4672bf205cb7b756ba2e20c95729b24e878b96e66f3
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:7.18.0":
+"@typescript-eslint/utils@npm:7.18.0, @typescript-eslint/utils@npm:^6.0.0 || ^7.0.0":
   version: 7.18.0
   resolution: "@typescript-eslint/utils@npm:7.18.0"
   dependencies:
@@ -3037,13 +2248,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:7.17.0":
-  version: 7.17.0
-  resolution: "@typescript-eslint/visitor-keys@npm:7.17.0"
+"@typescript-eslint/utils@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@typescript-eslint/utils@npm:8.0.0"
   dependencies:
-    "@typescript-eslint/types": "npm:7.17.0"
-    eslint-visitor-keys: "npm:^3.4.3"
-  checksum: 10/a8bef372e212baab67ec4e074a8b4983348fc554874d40d1fc22c10ce2693609cdef4a215391e8b428a67b3e2dcbda12d821b4ed668394b0b001ba03a08c5145
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@typescript-eslint/scope-manager": "npm:8.0.0"
+    "@typescript-eslint/types": "npm:8.0.0"
+    "@typescript-eslint/typescript-estree": "npm:8.0.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+  checksum: 10/f76e65763725d944d3c6f0e78ea566cdb08247fa7ee9e2ec15310527f3e2325c92cb67c80a63e4a6dd29a5a7d96db3839aebd0a2e98810dcc248f6762414c995
   languageName: node
   linkType: hard
 
@@ -3057,10 +2272,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abbrev@npm:^1.0.0":
-  version: 1.1.1
-  resolution: "abbrev@npm:1.1.1"
-  checksum: 10/2d882941183c66aa665118bafdab82b7a177e9add5eb2776c33e960a4f3c89cff88a1b38aba13a456de01d0dd9d66a8bea7c903268b21ea91dd1097e1e2e8243
+"@typescript-eslint/visitor-keys@npm:8.0.0":
+  version: 8.0.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.0.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.0.0"
+    eslint-visitor-keys: "npm:^3.4.3"
+  checksum: 10/328106878ed42f1543590317477275a3c95c0455ba8203355fede94b0970844ec430cc5e090d4e1f48d805ac40ab1bd339270514e256b0810cabd423c6b2d52a
+  languageName: node
+  linkType: hard
+
+"abbrev@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "abbrev@npm:2.0.0"
+  checksum: 10/ca0a54e35bea4ece0ecb68a47b312e1a9a6f772408d5bcb9051230aaa94b0460671c5b5c9cb3240eb5b7bc94c52476550eb221f65a0bbd0145bdc9f3113a6707
   languageName: node
   linkType: hard
 
@@ -3073,15 +2298,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.3":
-  version: 8.11.3
-  resolution: "acorn@npm:8.11.3"
-  bin:
-    acorn: bin/acorn
-  checksum: 10/b688e7e3c64d9bfb17b596e1b35e4da9d50553713b3b3630cf5690f2b023a84eac90c56851e6912b483fe60e8b4ea28b254c07e92f17ef83d72d78745a8352dd
-  languageName: node
-  linkType: hard
-
 "acorn@npm:^8.12.0, acorn@npm:^8.12.1":
   version: 8.12.1
   resolution: "acorn@npm:8.12.1"
@@ -3091,23 +2307,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:6, agent-base@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "agent-base@npm:6.0.2"
+"agent-base@npm:^7.0.2, agent-base@npm:^7.1.0, agent-base@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "agent-base@npm:7.1.1"
   dependencies:
-    debug: "npm:4"
-  checksum: 10/21fb903e0917e5cb16591b4d0ef6a028a54b83ac30cd1fca58dece3d4e0990512a8723f9f83130d88a41e2af8b1f7be1386fda3ea2d181bb1a62155e75e95e23
-  languageName: node
-  linkType: hard
-
-"agentkeepalive@npm:^4.2.1":
-  version: 4.3.0
-  resolution: "agentkeepalive@npm:4.3.0"
-  dependencies:
-    debug: "npm:^4.1.0"
-    depd: "npm:^2.0.0"
-    humanize-ms: "npm:^1.2.1"
-  checksum: 10/f791317eb4b42278d094547669b9b745e19e5d783bb42a8695820c94098ef18fc99f9d2777b5871cae76d761e45b0add8e6703e044de5d74d47181038ec7b536
+    debug: "npm:^4.3.4"
+  checksum: 10/c478fec8f79953f118704d007a38f2a185458853f5c45579b9669372bd0e12602e88dc2ad0233077831504f7cd6fcc8251c383375bba5eaaf563b102938bda26
   languageName: node
   linkType: hard
 
@@ -3134,11 +2339,11 @@ __metadata:
   linkType: hard
 
 "ansi-escapes@npm:^4.2.1":
-  version: 4.3.1
-  resolution: "ansi-escapes@npm:4.3.1"
+  version: 4.3.2
+  resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
-    type-fest: "npm:^0.11.0"
-  checksum: 10/964adff8777113109cc08e2e053af948a49137c52e86e427dc3cbfb515d0363763a731b96a0ef573531db3f788e1b45322d3cf13a7f4db9029a0f5ba17e9a14a
+    type-fest: "npm:^0.21.3"
+  checksum: 10/8661034456193ffeda0c15c8c564a9636b0c04094b7f78bd01517929c17c504090a60f7a75f949f5af91289c264d3e1001d91492c1bd58efc8e100500ce04de2
   languageName: node
   linkType: hard
 
@@ -3146,6 +2351,13 @@ __metadata:
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
   checksum: 10/2aa4bb54caf2d622f1afdad09441695af2a83aa3fe8b8afa581d205e57ed4261c183c4d3877cee25794443fde5876417d859c108078ab788d6af7e4fe52eb66b
+  languageName: node
+  linkType: hard
+
+"ansi-regex@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "ansi-regex@npm:6.0.1"
+  checksum: 10/1ff8b7667cded1de4fa2c9ae283e979fc87036864317da86a2e546725f96406746411d0d85e87a2d12fa5abd715d90006de7fa4fa0477c92321ad3b4c7d4e169
   languageName: node
   linkType: hard
 
@@ -3174,30 +2386,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-styles@npm:^6.1.0":
+  version: 6.2.1
+  resolution: "ansi-styles@npm:6.2.1"
+  checksum: 10/70fdf883b704d17a5dfc9cde206e698c16bcd74e7f196ab821511651aee4f9f76c9514bdfa6ca3a27b5e49138b89cb222a28caf3afe4567570139577f991df32
+  languageName: node
+  linkType: hard
+
 "anymatch@npm:^3.0.3":
-  version: 3.1.1
-  resolution: "anymatch@npm:3.1.1"
+  version: 3.1.3
+  resolution: "anymatch@npm:3.1.3"
   dependencies:
     normalize-path: "npm:^3.0.0"
     picomatch: "npm:^2.0.4"
-  checksum: 10/c951385862bf114807d594bdffccb769bd7219ddc14f24fc135cde075ad2477a97991567b8bb5032d4f279f96897f0c2af6468a350a6c674ac0a5ee3b62a26d6
-  languageName: node
-  linkType: hard
-
-"aproba@npm:^1.0.3 || ^2.0.0":
-  version: 2.0.0
-  resolution: "aproba@npm:2.0.0"
-  checksum: 10/c2b9a631298e8d6f3797547e866db642f68493808f5b37cd61da778d5f6ada890d16f668285f7d60bd4fc3b03889bd590ffe62cf81b700e9bb353431238a0a7b
-  languageName: node
-  linkType: hard
-
-"are-we-there-yet@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "are-we-there-yet@npm:3.0.1"
-  dependencies:
-    delegates: "npm:^1.0.0"
-    readable-stream: "npm:^3.6.0"
-  checksum: 10/390731720e1bf9ed5d0efc635ea7df8cbc4c90308b0645a932f06e8495a0bf1ecc7987d3b97e805f62a17d6c4b634074b25200aa4d149be2a7b17250b9744bc4
+  checksum: 10/3e044fd6d1d26545f235a9fe4d7a534e2029d8e59fa7fd9f2a6eb21230f6b5380ea1eaf55136e60cbf8e613544b3b766e7a6fa2102e2a3a117505466e3025dc2
   languageName: node
   linkType: hard
 
@@ -3217,10 +2419,60 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-buffer-byte-length@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "array-buffer-byte-length@npm:1.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.5"
+    is-array-buffer: "npm:^3.0.4"
+  checksum: 10/53524e08f40867f6a9f35318fafe467c32e45e9c682ba67b11943e167344d2febc0f6977a17e699b05699e805c3e8f073d876f8bbf1b559ed494ad2cd0fae09e
+  languageName: node
+  linkType: hard
+
 "array-union@npm:^2.1.0":
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
   checksum: 10/5bee12395cba82da674931df6d0fea23c4aa4660cb3b338ced9f828782a65caa232573e6bf3968f23e0c5eb301764a382cef2f128b170a9dc59de0e36c39f98d
+  languageName: node
+  linkType: hard
+
+"array.prototype.reduce@npm:^1.0.6":
+  version: 1.0.7
+  resolution: "array.prototype.reduce@npm:1.0.7"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.2"
+    es-array-method-boxes-properly: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.0.0"
+    is-string: "npm:^1.0.7"
+  checksum: 10/3a4fa56cf5843d821e97680861c8edfdfe6684a7f7cd1145ed611b5fa611fd62d1b149a438ae24ae884c843876a6539b67fbcacdd3276f89731eee9415dc9012
+  languageName: node
+  linkType: hard
+
+"arraybuffer.prototype.slice@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "arraybuffer.prototype.slice@npm:1.0.3"
+  dependencies:
+    array-buffer-byte-length: "npm:^1.0.1"
+    call-bind: "npm:^1.0.5"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.22.3"
+    es-errors: "npm:^1.2.1"
+    get-intrinsic: "npm:^1.2.3"
+    is-array-buffer: "npm:^3.0.4"
+    is-shared-array-buffer: "npm:^1.0.2"
+  checksum: 10/0221f16c1e3ec7b67da870ee0e1f12b825b5f9189835392b59a22990f715827561a4f4cd5330dc7507de272d8df821be6cd4b0cb569babf5ea4be70e365a2f3d
+  languageName: node
+  linkType: hard
+
+"available-typed-arrays@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "available-typed-arrays@npm:1.0.7"
+  dependencies:
+    possible-typed-array-names: "npm:^1.0.0"
+  checksum: 10/6c9da3a66caddd83c875010a1ca8ef11eac02ba15fb592dc9418b2b5e7b77b645fa7729380a92d9835c2f05f2ca1b6251f39b993e0feb3f1517c74fa1af02cab
   languageName: node
   linkType: hard
 
@@ -3303,8 +2555,8 @@ __metadata:
   linkType: hard
 
 "babel-preset-current-node-syntax@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "babel-preset-current-node-syntax@npm:1.0.0"
+  version: 1.0.1
+  resolution: "babel-preset-current-node-syntax@npm:1.0.1"
   dependencies:
     "@babel/plugin-syntax-async-generators": "npm:^7.8.4"
     "@babel/plugin-syntax-bigint": "npm:^7.8.3"
@@ -3320,7 +2572,7 @@ __metadata:
     "@babel/plugin-syntax-top-level-await": "npm:^7.8.3"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10/2d45944dc78da3a7ec3bce2a48664bd33e21f5b718a724cc2860921d2e2152678a3de50df9a8d5add8c3c3a10b444925f03ead28090c9dde89ea695044a010db
+  checksum: 10/94561959cb12bfa80867c9eeeace7c3d48d61707d33e55b4c3fdbe82fc745913eb2dbfafca62aef297421b38aadcb58550e5943f50fbcebbeefd70ce2bed4b74
   languageName: node
   linkType: hard
 
@@ -3337,9 +2589,9 @@ __metadata:
   linkType: hard
 
 "balanced-match@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "balanced-match@npm:1.0.0"
-  checksum: 10/9b67bfe558772f40cf743a3469b48b286aecec2ea9fe80c48d74845e53aab1cef524fafedf123a63019b49ac397760573ef5f173f539423061f7217cbb5fbd40
+  version: 1.0.2
+  resolution: "balanced-match@npm:1.0.2"
+  checksum: 10/9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
   languageName: node
   linkType: hard
 
@@ -3362,42 +2614,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.1":
-  version: 3.0.2
-  resolution: "braces@npm:3.0.2"
+"braces@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "braces@npm:3.0.3"
   dependencies:
-    fill-range: "npm:^7.0.1"
-  checksum: 10/966b1fb48d193b9d155f810e5efd1790962f2c4e0829f8440b8ad236ba009222c501f70185ef732fef17a4c490bb33a03b90dab0631feafbdf447da91e8165b1
-  languageName: node
-  linkType: hard
-
-"browserslist@npm:^4.17.5":
-  version: 4.19.1
-  resolution: "browserslist@npm:4.19.1"
-  dependencies:
-    caniuse-lite: "npm:^1.0.30001286"
-    electron-to-chromium: "npm:^1.4.17"
-    escalade: "npm:^3.1.1"
-    node-releases: "npm:^2.0.1"
-    picocolors: "npm:^1.0.0"
-  bin:
-    browserslist: cli.js
-  checksum: 10/c7044385e9397846a539ca9029b97e2a92e0b53cdc2eddb0d7cc84103c5cb22aaf73c7d3495026d62165e85f5222417cfed7bb8aa627ecfc4b94ba497d7d1f68
-  languageName: node
-  linkType: hard
-
-"browserslist@npm:^4.20.2":
-  version: 4.20.3
-  resolution: "browserslist@npm:4.20.3"
-  dependencies:
-    caniuse-lite: "npm:^1.0.30001332"
-    electron-to-chromium: "npm:^1.4.118"
-    escalade: "npm:^3.1.1"
-    node-releases: "npm:^2.0.3"
-    picocolors: "npm:^1.0.0"
-  bin:
-    browserslist: cli.js
-  checksum: 10/63e285ae2d19aca763616a48b3ad48dc84fb896038faa3a85bcfed801411ed783fd166bdbf5f4af0d11494ea1b6632aa390a4ba32ce92249bd627f4563c88cd0
+    fill-range: "npm:^7.1.1"
+  checksum: 10/fad11a0d4697a27162840b02b1fad249c1683cbc510cd5bf1a471f2f8085c046d41094308c577a50a03a579dd99d5a6b3724c4b5e8b14df2c4443844cfcda2c6
   languageName: node
   linkType: hard
 
@@ -3425,35 +2647,42 @@ __metadata:
   linkType: hard
 
 "buffer-from@npm:^1.0.0":
-  version: 1.1.1
-  resolution: "buffer-from@npm:1.1.1"
-  checksum: 10/ccc53b69736008bff764497367c4d24879ba7122bc619ee499ff47eef3a5b885ca496e87272e7ebffa0bec3804c83f84041c616f6e3318f40624e27c1d80f045
+  version: 1.1.2
+  resolution: "buffer-from@npm:1.1.2"
+  checksum: 10/0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
   languageName: node
   linkType: hard
 
-"cacache@npm:^16.1.0":
-  version: 16.1.3
-  resolution: "cacache@npm:16.1.3"
+"cacache@npm:^18.0.0":
+  version: 18.0.4
+  resolution: "cacache@npm:18.0.4"
   dependencies:
-    "@npmcli/fs": "npm:^2.1.0"
-    "@npmcli/move-file": "npm:^2.0.0"
-    chownr: "npm:^2.0.0"
-    fs-minipass: "npm:^2.1.0"
-    glob: "npm:^8.0.1"
-    infer-owner: "npm:^1.0.4"
-    lru-cache: "npm:^7.7.1"
-    minipass: "npm:^3.1.6"
-    minipass-collect: "npm:^1.0.2"
+    "@npmcli/fs": "npm:^3.1.0"
+    fs-minipass: "npm:^3.0.0"
+    glob: "npm:^10.2.2"
+    lru-cache: "npm:^10.0.1"
+    minipass: "npm:^7.0.3"
+    minipass-collect: "npm:^2.0.1"
     minipass-flush: "npm:^1.0.5"
     minipass-pipeline: "npm:^1.2.4"
-    mkdirp: "npm:^1.0.4"
     p-map: "npm:^4.0.0"
-    promise-inflight: "npm:^1.0.1"
-    rimraf: "npm:^3.0.2"
-    ssri: "npm:^9.0.0"
+    ssri: "npm:^10.0.0"
     tar: "npm:^6.1.11"
-    unique-filename: "npm:^2.0.0"
-  checksum: 10/a14524d90e377ee691d63a81173b33c473f8bc66eb299c64290b58e1d41b28842397f8d6c15a01b4c57ca340afcec019ae112a45c2f67a79f76130d326472e92
+    unique-filename: "npm:^3.0.0"
+  checksum: 10/ca2f7b2d3003f84d362da9580b5561058ccaecd46cba661cbcff0375c90734b610520d46b472a339fd032d91597ad6ed12dde8af81571197f3c9772b5d35b104
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.2, call-bind@npm:^1.0.5, call-bind@npm:^1.0.6, call-bind@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "call-bind@npm:1.0.7"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+    get-intrinsic: "npm:^1.2.4"
+    set-function-length: "npm:^1.2.1"
+  checksum: 10/cd6fe658e007af80985da5185bff7b55e12ef4c2b6f41829a26ed1eef254b1f1c12e3dfd5b2b068c6ba8b86aba62390842d81752e67dcbaec4f6f76e7113b6b7
   languageName: node
   linkType: hard
 
@@ -3478,28 +2707,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001286":
-  version: 1.0.30001286
-  resolution: "caniuse-lite@npm:1.0.30001286"
-  checksum: 10/fb2e9c4f8a815bee3d0f131b32e24e10341eeed5e260938f74287220c1609d9f463f7fbfc71481861f1ad0f915c59cf511af5b91143d27bcb8a2d92c38b10086
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001332":
-  version: 1.0.30001334
-  resolution: "caniuse-lite@npm:1.0.30001334"
-  checksum: 10/b973fbe8d32920a68ee2f581f1e49161acdf510037455072aacd4c30c4ea0f2b88573c5e99f6edc1dc92685c0ffad6ca9ac4d9754ddcb66b40991fc466510179
-  languageName: node
-  linkType: hard
-
 "caniuse-lite@npm:^1.0.30001640":
-  version: 1.0.30001643
-  resolution: "caniuse-lite@npm:1.0.30001643"
-  checksum: 10/dddbda29fa24fbc435873309c71070461cbfc915d9bce3216180524c20c5637b2bee1a14b45972e9ac19e1fdf63fba3f63608b9e7d68de32f5ee1953c8c69e05
+  version: 1.0.30001645
+  resolution: "caniuse-lite@npm:1.0.30001645"
+  checksum: 10/a59d80e5a1f062e0ede67d57c901144a1ecb4c093f58a34438cecdb6be4feaadd8017db86c3a95e6a73cef363a8c68c31fca772ff29b3d0d0db4e2aa66722a96
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.0.0, chalk@npm:^2.4.2":
+"chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -3542,16 +2757,16 @@ __metadata:
   linkType: hard
 
 "ci-info@npm:^3.2.0":
-  version: 3.3.0
-  resolution: "ci-info@npm:3.3.0"
-  checksum: 10/8adea555a4f92e4f80f5e58e63277b349efa439dabfc6e2ca3773126f3fea7699f3546ff931f996a08f9905b2f6a7fc4d671a0c549cfedab7369e35aa0723b00
+  version: 3.9.0
+  resolution: "ci-info@npm:3.9.0"
+  checksum: 10/75bc67902b4d1c7b435497adeb91598f6d52a3389398e44294f6601b20cfef32cf2176f7be0eb961d9e085bb333a8a5cae121cb22f81cf238ae7f58eb80e9397
   languageName: node
   linkType: hard
 
 "cjs-module-lexer@npm:^1.0.0":
-  version: 1.2.2
-  resolution: "cjs-module-lexer@npm:1.2.2"
-  checksum: 10/f80f84bfdcc53379cc18e25ea3c0cdb4595c142b8e28df304f5c88f38202e1bccf13e845401593656781f79fb43273e1d402d6187d0eeee8dca5ddecee1dcad4
+  version: 1.3.1
+  resolution: "cjs-module-lexer@npm:1.3.1"
+  checksum: 10/6629188d5ce74b57e5dce2222db851b5496a8d65b533a05957fb24089a3cec8d769378013c375a954c5a0f7522cde6a36d5a65bfd88f5575cb2de3176046fa8e
   languageName: node
   linkType: hard
 
@@ -3592,9 +2807,9 @@ __metadata:
   linkType: hard
 
 "collect-v8-coverage@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "collect-v8-coverage@npm:1.0.1"
-  checksum: 10/85b26945ab9b8e15077f877a4a5bc91d836480c600bac4cd0a0e8be8515583fdfc393ccff049ff3e9f46cac39e5295af049209f3c484f30a028056cc5dd1fe8a
+  version: 1.0.2
+  resolution: "collect-v8-coverage@npm:1.0.2"
+  checksum: 10/30ea7d5c9ee51f2fdba4901d4186c5b7114a088ef98fd53eda3979da77eed96758a2cae81cc6d97e239aaea6065868cf908b24980663f7b7e96aa291b3e12fa4
   languageName: node
   linkType: hard
 
@@ -3630,15 +2845,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-support@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "color-support@npm:1.1.3"
-  bin:
-    color-support: bin.js
-  checksum: 10/4bcfe30eea1498fe1cabc852bbda6c9770f230ea0e4faf4611c5858b1b9e4dde3730ac485e65f54ca182f4c50b626c1bea7c8441ceda47367a54a818c248aa7a
-  languageName: node
-  linkType: hard
-
 "commander@npm:^6.2.0":
   version: 6.2.1
   resolution: "commander@npm:6.2.1"
@@ -3660,22 +2866,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"console-control-strings@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "console-control-strings@npm:1.1.0"
-  checksum: 10/27b5fa302bc8e9ae9e98c03c66d76ca289ad0c61ce2fe20ab288d288bee875d217512d2edb2363fc83165e88f1c405180cf3f5413a46e51b4fe1a004840c6cdb
-  languageName: node
-  linkType: hard
-
-"convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
-  version: 1.7.0
-  resolution: "convert-source-map@npm:1.7.0"
-  dependencies:
-    safe-buffer: "npm:~5.1.1"
-  checksum: 10/0d0dd324ad15850cf1d44520560ab524ba3fce7ed8296df10d9aa466a0e964df9c9de0dcb78fb70a60493800b256ffe40d64f24968e32a48a1bcbff117102022
-  languageName: node
-  linkType: hard
-
 "convert-source-map@npm:^2.0.0":
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
@@ -3692,14 +2882,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.30.2":
-  version: 3.30.2
-  resolution: "core-js@npm:3.30.2"
-  checksum: 10/7476995aad7b01e51240fa1b19a26ec064825feece47290903d392e8b624749d06e8d72ce4c2ede9ab02afe34c6c08c001fd288bc1cfa3f5593ab03f2778719e
-  languageName: node
-  linkType: hard
-
-"core-js@npm:~3.37.1":
+"core-js@npm:^3.30.2, core-js@npm:~3.37.1":
   version: 3.37.1
   resolution: "core-js@npm:3.37.1"
   checksum: 10/25d6bd15fcc6ffd2a0ec0be57a78ff3358b3e1fdffdb6800fc93dcfdb3854037aee41f3d101aed8c37905d107daf98218b3e7ee95cec383710d2a66a5d9e541b
@@ -3723,7 +2906,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -3734,27 +2917,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.1, debug@npm:^4.3.3, debug@npm:^4.3.4":
-  version: 4.3.4
-  resolution: "debug@npm:4.3.4"
+"data-view-buffer@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "data-view-buffer@npm:1.0.1"
   dependencies:
-    ms: "npm:2.1.2"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 10/0073c3bcbd9cb7d71dd5f6b55be8701af42df3e56e911186dfa46fac3a5b9eb7ce7f377dd1d3be6db8977221f8eb333d945216f645cf56f6b688cd484837d255
+    call-bind: "npm:^1.0.6"
+    es-errors: "npm:^1.3.0"
+    is-data-view: "npm:^1.0.1"
+  checksum: 10/5919a39a18ee919573336158fd162fdf8ada1bc23a139f28543fd45fac48e0ea4a3ad3bfde91de124d4106e65c4a7525f6a84c20ba0797ec890a77a96d13a82a
   languageName: node
   linkType: hard
 
-"debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2":
-  version: 4.3.3
-  resolution: "debug@npm:4.3.3"
+"data-view-byte-length@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "data-view-byte-length@npm:1.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    es-errors: "npm:^1.3.0"
+    is-data-view: "npm:^1.0.1"
+  checksum: 10/f33c65e58d8d0432ad79761f2e8a579818d724b5dc6dc4e700489b762d963ab30873c0f1c37d8f2ed12ef51c706d1195f64422856d25f067457aeec50cc40aac
+  languageName: node
+  linkType: hard
+
+"data-view-byte-offset@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "data-view-byte-offset@npm:1.0.0"
+  dependencies:
+    call-bind: "npm:^1.0.6"
+    es-errors: "npm:^1.3.0"
+    is-data-view: "npm:^1.0.1"
+  checksum: 10/96f34f151bf02affb7b9f98762fb7aca1dd5f4553cb57b80bce750ca609c15d33ca659568ef1d422f7e35680736cbccb893a3d4b012760c758c1446bbdc4c6db
+  languageName: node
+  linkType: hard
+
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
+  version: 4.3.6
+  resolution: "debug@npm:4.3.6"
   dependencies:
     ms: "npm:2.1.2"
   peerDependenciesMeta:
     supports-color:
       optional: true
-  checksum: 10/723a9570dcd15d146ea4992f0dca12467d1b00f534abb42473df166d36826fcae8bab045aef59ac2f407b47a23266110bc0e646df8ac82f7800c11384f82050e
+  checksum: 10/d3adb9af7d57a9e809a68f404490cf776122acca16e6359a2702c0f462e510e91f9765c07f707b8ab0d91e03bad57328f3256f5082631cefb5393d0394d50fb7
   languageName: node
   linkType: hard
 
@@ -3771,39 +2975,38 @@ __metadata:
   linkType: hard
 
 "deep-is@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "deep-is@npm:0.1.3"
-  checksum: 10/dee1094e987a784a9a9c8549fc65eeca3422aef3bf2f9579f76c126085f280311d09273826c2f430d84fd09d64f6a578e5e7a4ac6ba1d50ea6cff0ddf605c025
+  version: 0.1.4
+  resolution: "deep-is@npm:0.1.4"
+  checksum: 10/ec12d074aef5ae5e81fa470b9317c313142c9e8e2afe3f8efa124db309720db96d1d222b82b84c834e5f87e7a614b44a4684b6683583118b87c833b3be40d4d8
   languageName: node
   linkType: hard
 
 "deepmerge@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "deepmerge@npm:4.2.2"
-  checksum: 10/0e58ed14f530d08f9b996cfc3a41b0801691620235bc5e1883260e3ed1c1b4a1dfb59f865770e45d5dfb1d7ee108c4fc10c2f85e822989d4123490ea90be2545
+  version: 4.3.1
+  resolution: "deepmerge@npm:4.3.1"
+  checksum: 10/058d9e1b0ff1a154468bf3837aea436abcfea1ba1d165ddaaf48ca93765fdd01a30d33c36173da8fbbed951dd0a267602bc782fe288b0fc4b7e1e7091afc4529
   languageName: node
   linkType: hard
 
-"define-properties@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "define-properties@npm:1.1.3"
+"define-data-property@npm:^1.0.1, define-data-property@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "define-data-property@npm:1.1.4"
   dependencies:
-    object-keys: "npm:^1.0.12"
-  checksum: 10/33125cafaf4de2c9934cfba20e0a45bccc53fa6d85370a48c0b5a9a0c76c7d0497a5fdf01bc5c1186cb61f2747f19f43520ca6fdd37b4d0290f552c6747e0a17
+    es-define-property: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.0.1"
+  checksum: 10/abdcb2505d80a53524ba871273e5da75e77e52af9e15b3aa65d8aad82b8a3a424dad7aee2cc0b71470ac7acf501e08defac362e8b6a73cdb4309f028061df4ae
   languageName: node
   linkType: hard
 
-"delegates@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "delegates@npm:1.0.0"
-  checksum: 10/a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
-  languageName: node
-  linkType: hard
-
-"depd@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "depd@npm:2.0.0"
-  checksum: 10/c0c8ff36079ce5ada64f46cc9d6fd47ebcf38241105b6e0c98f412e8ad91f084bcf906ff644cc3a4bd876ca27a62accb8b0fff72ea6ed1a414b89d8506f4a5ca
+"define-properties@npm:^1.2.0, define-properties@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "define-properties@npm:1.2.1"
+  dependencies:
+    define-data-property: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.0"
+    object-keys: "npm:^1.1.1"
+  checksum: 10/b4ccd00597dd46cb2d4a379398f5b19fca84a16f3374e2249201992f36b30f6835949a9429669ee6b41b6e837205a163eadd745e472069e70dfc10f03e5fcc12
   languageName: node
   linkType: hard
 
@@ -3837,24 +3040,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.4.118":
-  version: 1.4.127
-  resolution: "electron-to-chromium@npm:1.4.127"
-  checksum: 10/c649d0a90f08dabdb0faa62cd67f085ebd3a27a99d6c0a2a06fe284f5bea9159a78a7583666bcb5f27ed3cde76f218e3c6d0e4b40292cddb5826b9f9b4136aed
-  languageName: node
-  linkType: hard
-
-"electron-to-chromium@npm:^1.4.17":
-  version: 1.4.18
-  resolution: "electron-to-chromium@npm:1.4.18"
-  checksum: 10/ccbad17654e55a1a8ea319dc7f0fa46c38645f0da32835e618130e35d58923142545a930b924f22fd69a07f911f170d8a7b64776664d34e07c28c9070540728b
+"eastasianwidth@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "eastasianwidth@npm:0.2.0"
+  checksum: 10/9b1d3e1baefeaf7d70799db8774149cef33b97183a6addceeba0cf6b85ba23ee2686f302f14482006df32df75d32b17c509c143a3689627929e4a8efaf483952
   languageName: node
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.820":
-  version: 1.5.2
-  resolution: "electron-to-chromium@npm:1.5.2"
-  checksum: 10/5b397518bf3347e39935d1bf9ff3dd37064619783419c0cb6507c53812b3cea7b2cfd9c54664e6fc36aae28a29562af6339fa8e8fe165845355056ce3df63bde
+  version: 1.5.4
+  resolution: "electron-to-chromium@npm:1.5.4"
+  checksum: 10/ce64db25c399d33830e74e58bbc5ab7c06948669e204b6508e98c278ddaead1da1cbb356d15b55eb659f89d4d7bcf00944f08f96e886f1d3d065ba11744c5633
   languageName: node
   linkType: hard
 
@@ -3869,6 +3065,13 @@ __metadata:
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
   checksum: 10/c72d67a6821be15ec11997877c437491c313d924306b8da5d87d2a2bcc2cec9903cb5b04ee1a088460501d8e5b44f10df82fdc93c444101a7610b80c8b6938e1
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "emoji-regex@npm:9.2.2"
+  checksum: 10/915acf859cea7131dac1b2b5c9c8e35c4849e325a1d114c30adb8cd615970f6dca0e27f64f3a4949d7d6ed86ecd79a1c5c63f02e697513cddd7b5835c90948b8
   languageName: node
   linkType: hard
 
@@ -3904,42 +3107,100 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.17.0-next.1, es-abstract@npm:^1.17.5":
-  version: 1.17.7
-  resolution: "es-abstract@npm:1.17.7"
+"es-abstract@npm:^1.22.1, es-abstract@npm:^1.22.3, es-abstract@npm:^1.23.0, es-abstract@npm:^1.23.2":
+  version: 1.23.3
+  resolution: "es-abstract@npm:1.23.3"
   dependencies:
+    array-buffer-byte-length: "npm:^1.0.1"
+    arraybuffer.prototype.slice: "npm:^1.0.3"
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.7"
+    data-view-buffer: "npm:^1.0.1"
+    data-view-byte-length: "npm:^1.0.1"
+    data-view-byte-offset: "npm:^1.0.0"
+    es-define-property: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.0.0"
+    es-set-tostringtag: "npm:^2.0.3"
     es-to-primitive: "npm:^1.2.1"
-    function-bind: "npm:^1.1.1"
-    has: "npm:^1.0.3"
-    has-symbols: "npm:^1.0.1"
-    is-callable: "npm:^1.2.2"
-    is-regex: "npm:^1.1.1"
-    object-inspect: "npm:^1.8.0"
+    function.prototype.name: "npm:^1.1.6"
+    get-intrinsic: "npm:^1.2.4"
+    get-symbol-description: "npm:^1.0.2"
+    globalthis: "npm:^1.0.3"
+    gopd: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.2"
+    has-proto: "npm:^1.0.3"
+    has-symbols: "npm:^1.0.3"
+    hasown: "npm:^2.0.2"
+    internal-slot: "npm:^1.0.7"
+    is-array-buffer: "npm:^3.0.4"
+    is-callable: "npm:^1.2.7"
+    is-data-view: "npm:^1.0.1"
+    is-negative-zero: "npm:^2.0.3"
+    is-regex: "npm:^1.1.4"
+    is-shared-array-buffer: "npm:^1.0.3"
+    is-string: "npm:^1.0.7"
+    is-typed-array: "npm:^1.1.13"
+    is-weakref: "npm:^1.0.2"
+    object-inspect: "npm:^1.13.1"
     object-keys: "npm:^1.1.1"
-    object.assign: "npm:^4.1.1"
-    string.prototype.trimend: "npm:^1.0.1"
-    string.prototype.trimstart: "npm:^1.0.1"
-  checksum: 10/1e43c7e9006eec907247a99162ec9580688ba2cb9a6c3753b2d7f7b7369b258111a67a48af780273b158a66e341a745327159797befecb3cd7a78f1b82bbeade
+    object.assign: "npm:^4.1.5"
+    regexp.prototype.flags: "npm:^1.5.2"
+    safe-array-concat: "npm:^1.1.2"
+    safe-regex-test: "npm:^1.0.3"
+    string.prototype.trim: "npm:^1.2.9"
+    string.prototype.trimend: "npm:^1.0.8"
+    string.prototype.trimstart: "npm:^1.0.8"
+    typed-array-buffer: "npm:^1.0.2"
+    typed-array-byte-length: "npm:^1.0.1"
+    typed-array-byte-offset: "npm:^1.0.2"
+    typed-array-length: "npm:^1.0.6"
+    unbox-primitive: "npm:^1.0.2"
+    which-typed-array: "npm:^1.1.15"
+  checksum: 10/2da795a6a1ac5fc2c452799a409acc2e3692e06dc6440440b076908617188899caa562154d77263e3053bcd9389a07baa978ab10ac3b46acc399bd0c77be04cb
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.18.0-next.0":
-  version: 1.18.0-next.1
-  resolution: "es-abstract@npm:1.18.0-next.1"
+"es-array-method-boxes-properly@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "es-array-method-boxes-properly@npm:1.0.0"
+  checksum: 10/27a8a21acf20f3f51f69dce8e643f151e380bffe569e95dc933b9ded9fcd89a765ee21b5229c93f9206c93f87395c6b75f80be8ac8c08a7ceb8771e1822ff1fb
+  languageName: node
+  linkType: hard
+
+"es-define-property@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "es-define-property@npm:1.0.0"
   dependencies:
-    es-to-primitive: "npm:^1.2.1"
-    function-bind: "npm:^1.1.1"
-    has: "npm:^1.0.3"
-    has-symbols: "npm:^1.0.1"
-    is-callable: "npm:^1.2.2"
-    is-negative-zero: "npm:^2.0.0"
-    is-regex: "npm:^1.1.1"
-    object-inspect: "npm:^1.8.0"
-    object-keys: "npm:^1.1.1"
-    object.assign: "npm:^4.1.1"
-    string.prototype.trimend: "npm:^1.0.1"
-    string.prototype.trimstart: "npm:^1.0.1"
-  checksum: 10/565733d186683366fbef3328f5b74102ca8bbb78c173ea82658071f312431b6aaa7b0a25bfb95323ef3c86c5956e3f7db8609f078c94bfd2516b8a598aaddc88
+    get-intrinsic: "npm:^1.2.4"
+  checksum: 10/f66ece0a887b6dca71848fa71f70461357c0e4e7249696f81bad0a1f347eed7b31262af4a29f5d726dc026426f085483b6b90301855e647aa8e21936f07293c6
+  languageName: node
+  linkType: hard
+
+"es-errors@npm:^1.2.1, es-errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "es-errors@npm:1.3.0"
+  checksum: 10/96e65d640156f91b707517e8cdc454dd7d47c32833aa3e85d79f24f9eb7ea85f39b63e36216ef0114996581969b59fe609a94e30316b08f5f4df1d44134cf8d5
+  languageName: node
+  linkType: hard
+
+"es-object-atoms@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "es-object-atoms@npm:1.0.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+  checksum: 10/f8910cf477e53c0615f685c5c96210591841850871b81924fcf256bfbaa68c254457d994a4308c60d15b20805e7f61ce6abc669375e01a5349391a8c1767584f
+  languageName: node
+  linkType: hard
+
+"es-set-tostringtag@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "es-set-tostringtag@npm:2.0.3"
+  dependencies:
+    get-intrinsic: "npm:^1.2.4"
+    has-tostringtag: "npm:^1.0.2"
+    hasown: "npm:^2.0.1"
+  checksum: 10/7227fa48a41c0ce83e0377b11130d324ac797390688135b8da5c28994c0165be8b252e15cd1de41e1325e5a5412511586960213e88f9ab4a5e7d028895db5129
   languageName: node
   linkType: hard
 
@@ -3954,14 +3215,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "escalade@npm:3.1.1"
-  checksum: 10/afa618e73362576b63f6ca83c975456621095a1ed42ff068174e3f5cea48afc422814dda548c96e6ebb5333e7265140c7292abcc81bbd6ccb1757d50d3a4e182
-  languageName: node
-  linkType: hard
-
-"escalade@npm:^3.1.2":
+"escalade@npm:^3.1.1, escalade@npm:^3.1.2":
   version: 3.1.2
   resolution: "escalade@npm:3.1.2"
   checksum: 10/a1e07fea2f15663c30e40b9193d658397846ffe28ce0a3e4da0d8e485fedfeca228ab846aee101a05015829adf39f9934ff45b2a3fca47bed37a29646bd05cd3
@@ -4028,14 +3282,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "eslint-visitor-keys@npm:3.3.0"
-  checksum: 10/37a1a5912a0b1de0f6d26237d8903af8a3af402bbef6e4181aeda1ace12a67348a0356c677804cfc839f62e68c3845b3eb96bb8f334d30d5ce96348d482567ed
-  languageName: node
-  linkType: hard
-
-"eslint-visitor-keys@npm:^3.4.3":
+"eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.3":
   version: 3.4.3
   resolution: "eslint-visitor-keys@npm:3.4.3"
   checksum: 10/3f357c554a9ea794b094a09bd4187e5eacd1bc0d0653c3adeb87962c548e6a1ab8f982b86963ae1337f5d976004146536dcee5d0e2806665b193fbfbf1a9231b
@@ -4093,18 +3340,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"espree@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "espree@npm:10.0.1"
-  dependencies:
-    acorn: "npm:^8.11.3"
-    acorn-jsx: "npm:^5.3.2"
-    eslint-visitor-keys: "npm:^4.0.0"
-  checksum: 10/557d6cfb4894b1489effcaed8702682086033f8a2449568933bc59493734733d750f2a87907ba575844d3933340aea2d84288f5e67020c6152f6fd18a86497b2
-  languageName: node
-  linkType: hard
-
-"espree@npm:^10.1.0":
+"espree@npm:^10.0.1, espree@npm:^10.1.0":
   version: 10.1.0
   resolution: "espree@npm:10.1.0"
   dependencies:
@@ -4144,9 +3380,9 @@ __metadata:
   linkType: hard
 
 "estraverse@npm:^5.1.0, estraverse@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "estraverse@npm:5.2.0"
-  checksum: 10/9740a8fa4257682c1d6c14a0befc884af31e76013a97c647aed21aeb1766270e153e34cc06ab8d354a377bb6ed6b785b1f5deb1228ceb7e3792bf88fb79b2ce8
+  version: 5.3.0
+  resolution: "estraverse@npm:5.3.0"
+  checksum: 10/37cbe6e9a68014d34dbdc039f90d0baf72436809d02edffcc06ba3c2a12eb298048f877511353b130153e532aac8d68ba78430c0dd2f44806ebc7c014b01585e
   languageName: node
   linkType: hard
 
@@ -4194,6 +3430,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"exponential-backoff@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "exponential-backoff@npm:3.1.1"
+  checksum: 10/2d9bbb6473de7051f96790d5f9a678f32e60ed0aa70741dc7fdc96fec8d631124ec3374ac144387604f05afff9500f31a1d45bd9eee4cdc2e4f9ad2d9b9d5dbd
+  languageName: node
+  linkType: hard
+
 "fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -4202,15 +3445,15 @@ __metadata:
   linkType: hard
 
 "fast-glob@npm:^3.2.9":
-  version: 3.2.12
-  resolution: "fast-glob@npm:3.2.12"
+  version: 3.3.2
+  resolution: "fast-glob@npm:3.3.2"
   dependencies:
     "@nodelib/fs.stat": "npm:^2.0.2"
     "@nodelib/fs.walk": "npm:^1.2.3"
     glob-parent: "npm:^5.1.2"
     merge2: "npm:^1.3.0"
     micromatch: "npm:^4.0.4"
-  checksum: 10/641e748664ae0fdc4dadd23c812fd7d6c80cd92d451571cb1f81fa87edb750e917f25abf74fc9503c97438b0b67ecf75b738bb8e50a83b16bd2a88b4d64e81fa
+  checksum: 10/222512e9315a0efca1276af9adb2127f02105d7288fa746145bf45e2716383fb79eb983c89601a72a399a56b7c18d38ce70457c5466218c5f13fad957cee16df
   languageName: node
   linkType: hard
 
@@ -4229,20 +3472,20 @@ __metadata:
   linkType: hard
 
 "fastq@npm:^1.6.0":
-  version: 1.8.0
-  resolution: "fastq@npm:1.8.0"
+  version: 1.17.1
+  resolution: "fastq@npm:1.17.1"
   dependencies:
     reusify: "npm:^1.0.4"
-  checksum: 10/7b7908a90e908c7c19ea5237a4cf1380665df718f5b8f643ead5245b27be105e76c04405bef28c439018976eef1e8741fde3db382d6b06435c9990fe3ce3533e
+  checksum: 10/a443180068b527dd7b3a63dc7f2a47ceca2f3e97b9c00a1efe5538757e6cc4056a3526df94308075d7727561baf09ebaa5b67da8dcbddb913a021c5ae69d1f69
   languageName: node
   linkType: hard
 
 "fb-watchman@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "fb-watchman@npm:2.0.1"
+  version: 2.0.2
+  resolution: "fb-watchman@npm:2.0.2"
   dependencies:
     bser: "npm:2.1.1"
-  checksum: 10/9a03efc7d41ce3ca3d799d63505a1f7312caddf4e7737d39f2165bfe4872cbd4b87eccc9e6c57229ea08f14b4d7187896da31a7270b8da7a4aaa8fba2d3d1c42
+  checksum: 10/4f95d336fb805786759e383fd7fff342ceb7680f53efcc0ef82f502eb479ce35b98e8b207b6dfdfeea0eba845862107dc73813775fc6b56b3098c6e90a2dad77
   languageName: node
   linkType: hard
 
@@ -4255,12 +3498,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fill-range@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "fill-range@npm:7.0.1"
+"fill-range@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "fill-range@npm:7.1.1"
   dependencies:
     to-regex-range: "npm:^5.0.1"
-  checksum: 10/e260f7592fd196b4421504d3597cc76f4a1ca7a9488260d533b611fc3cefd61e9a9be1417cb82d3b01ad9f9c0ff2dbf258e1026d2445e26b0cf5148ff4250429
+  checksum: 10/a7095cb39e5bc32fada2aa7c7249d3f6b01bd1ce461a61b0adabacccabd9198500c6fb1f68a7c851a657e273fce2233ba869638897f3d7ed2e87a2d89b4436ea
   languageName: node
   linkType: hard
 
@@ -4321,12 +3564,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-minipass@npm:^2.0.0, fs-minipass@npm:^2.1.0":
+"for-each@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "for-each@npm:0.3.3"
+  dependencies:
+    is-callable: "npm:^1.1.3"
+  checksum: 10/fdac0cde1be35610bd635ae958422e8ce0cc1313e8d32ea6d34cfda7b60850940c1fd07c36456ad76bd9c24aef6ff5e03b02beb58c83af5ef6c968a64eada676
+  languageName: node
+  linkType: hard
+
+"foreground-child@npm:^3.1.0":
+  version: 3.2.1
+  resolution: "foreground-child@npm:3.2.1"
+  dependencies:
+    cross-spawn: "npm:^7.0.0"
+    signal-exit: "npm:^4.0.1"
+  checksum: 10/77b33b3c438a499201727ca84de39a66350ccd54a8805df712773e963cefb5c4632dbc4386109e97a0df8fb1585aee95fa35acb07587e3e04cfacabfc0ae15dc
+  languageName: node
+  linkType: hard
+
+"fs-minipass@npm:^2.0.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
   dependencies:
     minipass: "npm:^3.0.0"
   checksum: 10/03191781e94bc9a54bd376d3146f90fe8e082627c502185dbf7b9b3032f66b0b142c1115f3b2cc5936575fc1b44845ce903dd4c21bec2a8d69f3bd56f9cee9ec
+  languageName: node
+  linkType: hard
+
+"fs-minipass@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "fs-minipass@npm:3.0.3"
+  dependencies:
+    minipass: "npm:^7.0.3"
+  checksum: 10/af143246cf6884fe26fa281621d45cfe111d34b30535a475bfa38dafe343dadb466c047a924ffc7d6b7b18265df4110224ce3803806dbb07173bf2087b648d7f
   languageName: node
   linkType: hard
 
@@ -4338,44 +3609,47 @@ __metadata:
   linkType: hard
 
 "fsevents@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "fsevents@npm:2.3.2"
+  version: 2.3.3
+  resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
-  checksum: 10/6b5b6f5692372446ff81cf9501c76e3e0459a4852b3b5f1fc72c103198c125a6b8c72f5f166bdd76ffb2fca261e7f6ee5565daf80dca6e571e55bcc589cc1256
+  checksum: 10/4c1ade961ded57cdbfbb5cac5106ec17bc8bccd62e16343c569a0ceeca83b9dfef87550b4dc5cbb89642da412b20c5071f304c8c464b80415446e8e155a038c0
   conditions: os=darwin
   languageName: node
   linkType: hard
 
 "fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>":
-  version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  version: 2.3.3
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
     node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
 
-"function-bind@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "function-bind@npm:1.1.1"
-  checksum: 10/d83f2968030678f0b8c3f2183d63dcd969344eb8b55b4eb826a94ccac6de8b87c95bebffda37a6386c74f152284eb02956ff2c496897f35d32bdc2628ac68ac5
+"function-bind@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "function-bind@npm:1.1.2"
+  checksum: 10/185e20d20f10c8d661d59aac0f3b63b31132d492e1b11fcc2a93cb2c47257ebaee7407c38513efd2b35cafdf972d9beb2ea4593c1e0f3bf8f2744836928d7454
   languageName: node
   linkType: hard
 
-"gauge@npm:^4.0.3":
-  version: 4.0.4
-  resolution: "gauge@npm:4.0.4"
+"function.prototype.name@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "function.prototype.name@npm:1.1.6"
   dependencies:
-    aproba: "npm:^1.0.3 || ^2.0.0"
-    color-support: "npm:^1.1.3"
-    console-control-strings: "npm:^1.1.0"
-    has-unicode: "npm:^2.0.1"
-    signal-exit: "npm:^3.0.7"
-    string-width: "npm:^4.2.3"
-    strip-ansi: "npm:^6.0.1"
-    wide-align: "npm:^1.1.5"
-  checksum: 10/09535dd53b5ced6a34482b1fa9f3929efdeac02f9858569cde73cef3ed95050e0f3d095706c1689614059898924b7a74aa14042f51381a1ccc4ee5c29d2389c4
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.2.0"
+    es-abstract: "npm:^1.22.1"
+    functions-have-names: "npm:^1.2.3"
+  checksum: 10/4d40be44d4609942e4e90c4fff77a811fa936f4985d92d2abfcf44f673ba344e2962bf223a33101f79c1a056465f36f09b072b9c289d7660ca554a12491cd5a2
+  languageName: node
+  linkType: hard
+
+"functions-have-names@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "functions-have-names@npm:1.2.3"
+  checksum: 10/0ddfd3ed1066a55984aaecebf5419fbd9344a5c38dd120ffb0739fac4496758dcf371297440528b115e4367fc46e3abc86a2cc0ff44612181b175ae967a11a05
   languageName: node
   linkType: hard
 
@@ -4393,6 +3667,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.1, get-intrinsic@npm:^1.2.3, get-intrinsic@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "get-intrinsic@npm:1.2.4"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+    has-proto: "npm:^1.0.1"
+    has-symbols: "npm:^1.0.3"
+    hasown: "npm:^2.0.0"
+  checksum: 10/85bbf4b234c3940edf8a41f4ecbd4e25ce78e5e6ad4e24ca2f77037d983b9ef943fd72f00f3ee97a49ec622a506b67db49c36246150377efcda1c9eb03e5f06d
+  languageName: node
+  linkType: hard
+
 "get-package-type@npm:^0.1.0":
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
@@ -4404,6 +3691,17 @@ __metadata:
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: 10/781266d29725f35c59f1d214aedc92b0ae855800a980800e2923b3fbc4e56b3cb6e462c42e09a1cf1a00c64e056a78fa407cbe06c7c92b7e5cd49b4b85c2a497
+  languageName: node
+  linkType: hard
+
+"get-symbol-description@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "get-symbol-description@npm:1.0.2"
+  dependencies:
+    call-bind: "npm:^1.0.5"
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.4"
+  checksum: 10/e1cb53bc211f9dbe9691a4f97a46837a553c4e7caadd0488dc24ac694db8a390b93edd412b48dcdd0b4bbb4c595de1709effc75fc87c0839deedc6968f5bd973
   languageName: node
   linkType: hard
 
@@ -4425,30 +3723,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.0, glob@npm:^7.1.3, glob@npm:^7.1.4":
-  version: 7.1.6
-  resolution: "glob@npm:7.1.6"
+"glob@npm:^10.2.2, glob@npm:^10.3.10":
+  version: 10.4.5
+  resolution: "glob@npm:10.4.5"
   dependencies:
-    fs.realpath: "npm:^1.0.0"
-    inflight: "npm:^1.0.4"
-    inherits: "npm:2"
-    minimatch: "npm:^3.0.4"
-    once: "npm:^1.3.0"
-    path-is-absolute: "npm:^1.0.0"
-  checksum: 10/7d6ec98bc746980d5fe4d764b9c7ada727e3fbd2a7d85cd96dd95fb18638c9c54a70c692fd2ab5d68a186dc8cd9d6a4192d3df220beed891f687db179c430237
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^3.1.2"
+    minimatch: "npm:^9.0.4"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^1.11.1"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10/698dfe11828b7efd0514cd11e573eaed26b2dff611f0400907281ce3eab0c1e56143ef9b35adc7c77ecc71fba74717b510c7c223d34ca8a98ec81777b293d4ac
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.1":
-  version: 8.1.0
-  resolution: "glob@npm:8.1.0"
+"glob@npm:^7.0.0, glob@npm:^7.1.3, glob@npm:^7.1.4":
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
   dependencies:
     fs.realpath: "npm:^1.0.0"
     inflight: "npm:^1.0.4"
     inherits: "npm:2"
-    minimatch: "npm:^5.0.1"
+    minimatch: "npm:^3.1.1"
     once: "npm:^1.3.0"
-  checksum: 10/9aab1c75eb087c35dbc41d1f742e51d0507aa2b14c910d96fb8287107a10a22f4bbdce26fc0a3da4c69a20f7b26d62f1640b346a4f6e6becfff47f335bb1dc5e
+    path-is-absolute: "npm:^1.0.0"
+  checksum: 10/59452a9202c81d4508a43b8af7082ca5c76452b9fcc4a9ab17655822e6ce9b21d4f8fbadabe4fe3faef448294cec249af305e2cd824b7e9aaf689240e5e96a7b
   languageName: node
   linkType: hard
 
@@ -4473,6 +3774,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globalthis@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "globalthis@npm:1.0.4"
+  dependencies:
+    define-properties: "npm:^1.2.1"
+    gopd: "npm:^1.0.1"
+  checksum: 10/1f1fd078fb2f7296306ef9dd51019491044ccf17a59ed49d375b576ca108ff37e47f3d29aead7add40763574a992f16a5367dd1e2173b8634ef18556ab719ac4
+  languageName: node
+  linkType: hard
+
 "globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
@@ -4487,17 +3798,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.2.6":
-  version: 4.2.11
-  resolution: "graceful-fs@npm:4.2.11"
-  checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
+"gopd@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "gopd@npm:1.0.1"
+  dependencies:
+    get-intrinsic: "npm:^1.1.3"
+  checksum: 10/5fbc7ad57b368ae4cd2f41214bd947b045c1a4be2f194a7be1778d71f8af9dbf4004221f3b6f23e30820eb0d052b4f819fe6ebe8221e2a3c6f0ee4ef173421ca
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.2.9":
-  version: 4.2.9
-  resolution: "graceful-fs@npm:4.2.9"
-  checksum: 10/4bcf2de4f1108a928dd64d5e894b833cba634b2e82729c0e57f327d384bf15098e4706639f3045e587e845afed06bae52e70916f74a42db5a56e9ca44f6c2fd1
+"graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+  version: 4.2.11
+  resolution: "graceful-fs@npm:4.2.11"
+  checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
   languageName: node
   linkType: hard
 
@@ -4505,6 +3818,13 @@ __metadata:
   version: 1.4.0
   resolution: "graphemer@npm:1.4.0"
   checksum: 10/6dd60dba97007b21e3a829fab3f771803cc1292977fe610e240ea72afd67e5690ac9eeaafc4a99710e78962e5936ab5a460787c2a1180f1cb0ccfac37d29f897
+  languageName: node
+  linkType: hard
+
+"has-bigints@npm:^1.0.1, has-bigints@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-bigints@npm:1.0.2"
+  checksum: 10/4e0426c900af034d12db14abfece02ce7dbf53f2022d28af1a97913ff4c07adb8799476d57dc44fbca0e07d1dbda2a042c2928b1f33d3f09c15de0640a7fb81b
   languageName: node
   linkType: hard
 
@@ -4522,26 +3842,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-symbols@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "has-symbols@npm:1.0.1"
-  checksum: 10/d7a6d0b8f2b4595d6d5aafd4e020f65785779a654b52b77457f69c33e2c36400780ece296b964ae885714e4c83b503b01e2024d682d95794628d9c5a83c113bf
-  languageName: node
-  linkType: hard
-
-"has-unicode@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "has-unicode@npm:2.0.1"
-  checksum: 10/041b4293ad6bf391e21c5d85ed03f412506d6623786b801c4ab39e4e6ca54993f13201bceb544d92963f9e0024e6e7fbf0cb1d84c9d6b31cb9c79c8c990d13d8
-  languageName: node
-  linkType: hard
-
-"has@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "has@npm:1.0.3"
+"has-property-descriptors@npm:^1.0.0, has-property-descriptors@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-property-descriptors@npm:1.0.2"
   dependencies:
-    function-bind: "npm:^1.1.1"
-  checksum: 10/a449f3185b1d165026e8d25f6a8c3390bd25c201ff4b8c1aaf948fc6a5fcfd6507310b8c00c13a3325795ea9791fcc3d79d61eafa313b5750438fc19183df57b
+    es-define-property: "npm:^1.0.0"
+  checksum: 10/2d8c9ab8cebb572e3362f7d06139a4592105983d4317e68f7adba320fe6ddfc8874581e0971e899e633fd5f72e262830edce36d5a0bc863dad17ad20572484b2
+  languageName: node
+  linkType: hard
+
+"has-proto@npm:^1.0.1, has-proto@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "has-proto@npm:1.0.3"
+  checksum: 10/0b67c2c94e3bea37db3e412e3c41f79d59259875e636ba471e94c009cdfb1fa82bf045deeffafc7dbb9c148e36cae6b467055aaa5d9fad4316e11b41e3ba551a
+  languageName: node
+  linkType: hard
+
+"has-symbols@npm:^1.0.2, has-symbols@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "has-symbols@npm:1.0.3"
+  checksum: 10/464f97a8202a7690dadd026e6d73b1ceeddd60fe6acfd06151106f050303eaa75855aaa94969df8015c11ff7c505f196114d22f7386b4a471038da5874cf5e9b
+  languageName: node
+  linkType: hard
+
+"has-tostringtag@npm:^1.0.0, has-tostringtag@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-tostringtag@npm:1.0.2"
+  dependencies:
+    has-symbols: "npm:^1.0.3"
+  checksum: 10/c74c5f5ceee3c8a5b8bc37719840dc3749f5b0306d818974141dda2471a1a2ca6c8e46b9d6ac222c5345df7a901c9b6f350b1e6d62763fec877e26609a401bfe
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.0, hasown@npm:^2.0.1, hasown@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "hasown@npm:2.0.2"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10/7898a9c1788b2862cf0f9c345a6bec77ba4a0c0983c7f19d610c382343d4f98fa260686b225dfb1f88393a66679d2ec58ee310c1d6868c081eda7918f32cc70a
   languageName: node
   linkType: hard
 
@@ -4561,31 +3899,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-cache-semantics@npm:^4.1.0":
+"http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
   checksum: 10/362d5ed66b12ceb9c0a328fb31200b590ab1b02f4a254a697dc796850cc4385603e75f53ec59f768b2dad3bfa1464bd229f7de278d2899a0e3beffc634b6683f
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "http-proxy-agent@npm:5.0.0"
+"http-proxy-agent@npm:^7.0.0":
+  version: 7.0.2
+  resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
-    "@tootallnate/once": "npm:2"
-    agent-base: "npm:6"
-    debug: "npm:4"
-  checksum: 10/5ee19423bc3e0fd5f23ce991b0755699ad2a46a440ce9cec99e8126bb98448ad3479d2c0ea54be5519db5b19a4ffaa69616bac01540db18506dd4dac3dc418f0
+    agent-base: "npm:^7.1.0"
+    debug: "npm:^4.3.4"
+  checksum: 10/d062acfa0cb82beeb558f1043c6ba770ea892b5fb7b28654dbc70ea2aeea55226dd34c02a294f6c1ca179a5aa483c4ea641846821b182edbd9cc5d89b54c6848
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "https-proxy-agent@npm:5.0.1"
+"https-proxy-agent@npm:^7.0.1":
+  version: 7.0.5
+  resolution: "https-proxy-agent@npm:7.0.5"
   dependencies:
-    agent-base: "npm:6"
+    agent-base: "npm:^7.0.2"
     debug: "npm:4"
-  checksum: 10/f0dce7bdcac5e8eaa0be3c7368bb8836ed010fb5b6349ffb412b172a203efe8f807d9a6681319105ea1b6901e1972c7b5ea899672a7b9aad58309f766dcbe0df
+  checksum: 10/6679d46159ab3f9a5509ee80c3a3fc83fba3a920a5e18d32176c3327852c3c00ad640c0c4210a8fd70ea3c4a6d3a1b375bf01942516e7df80e2646bdc77658ab
   languageName: node
   linkType: hard
 
@@ -4593,15 +3930,6 @@ __metadata:
   version: 2.1.0
   resolution: "human-signals@npm:2.1.0"
   checksum: 10/df59be9e0af479036798a881d1f136c4a29e0b518d4abb863afbd11bf30efa3eeb1d0425fc65942dcc05ab3bf40205ea436b0ff389f2cd20b75b8643d539bf86
-  languageName: node
-  linkType: hard
-
-"humanize-ms@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "humanize-ms@npm:1.2.1"
-  dependencies:
-    ms: "npm:^2.0.0"
-  checksum: 10/9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
   languageName: node
   linkType: hard
 
@@ -4614,14 +3942,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "ignore@npm:5.2.0"
-  checksum: 10/30283f05fb7d867ee0e08faebb3e69caba2c6c55092042cd061eac1b37a3e78db72bfcfbb08b3598999344fba3d93a9c693b5401da5faaecc0fb7c2dce87beb4
-  languageName: node
-  linkType: hard
-
-"ignore@npm:^5.3.1":
+"ignore@npm:^5.2.0, ignore@npm:^5.3.1":
   version: 5.3.1
   resolution: "ignore@npm:5.3.1"
   checksum: 10/0a884c2fbc8c316f0b9f92beaf84464253b73230a4d4d286697be45fca081199191ca33e1c2e82d9e5f851f5e9a48a78e25a35c951e7eb41e59f150db3530065
@@ -4629,24 +3950,24 @@ __metadata:
   linkType: hard
 
 "import-fresh@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "import-fresh@npm:3.2.1"
+  version: 3.3.0
+  resolution: "import-fresh@npm:3.3.0"
   dependencies:
     parent-module: "npm:^1.0.0"
     resolve-from: "npm:^4.0.0"
-  checksum: 10/caef42418a087c3951fb676943a7f21ba8971aa07f9b622dff4af7edcef4160e1b172dccd85a88d7eb109cf41406a4592f70259e6b3b33aeafd042bb61f81d96
+  checksum: 10/2cacfad06e652b1edc50be650f7ec3be08c5e5a6f6d12d035c440a42a8cc028e60a5b99ca08a77ab4d6b1346da7d971915828f33cdab730d3d42f08242d09baa
   languageName: node
   linkType: hard
 
 "import-local@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "import-local@npm:3.0.2"
+  version: 3.2.0
+  resolution: "import-local@npm:3.2.0"
   dependencies:
     pkg-dir: "npm:^4.2.0"
     resolve-cwd: "npm:^3.0.0"
   bin:
     import-local-fixture: fixtures/cli.js
-  checksum: 10/c74d9f9484c878cda1de3434613c7ff72d5dadcf20e5482542232d7c2575b713ff88701d6675fcf09a3684cb23fb407c8b333b9cbc59438712723d058d8e976c
+  checksum: 10/0b0b0b412b2521739fbb85eeed834a3c34de9bc67e670b3d0b86248fc460d990a7b116ad056c084b87a693ef73d1f17268d6a5be626bb43c998a8b1c8a230004
   languageName: node
   linkType: hard
 
@@ -4664,13 +3985,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"infer-owner@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "infer-owner@npm:1.0.4"
-  checksum: 10/181e732764e4a0611576466b4b87dac338972b839920b2a8cde43642e4ed6bd54dc1fb0b40874728f2a2df9a1b097b8ff83b56d5f8f8e3927f837fdcb47d8a89
-  languageName: node
-  linkType: hard
-
 "inflight@npm:^1.0.4":
   version: 1.0.6
   resolution: "inflight@npm:1.0.6"
@@ -4681,10 +3995,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.3":
+"inherits@npm:2":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10/cd45e923bee15186c07fa4c89db0aace24824c482fb887b528304694b2aa6ff8a898da8657046a5dcf3e46cd6db6c61629551f9215f208d7c3f157cf9b290521
+  languageName: node
+  linkType: hard
+
+"internal-slot@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "internal-slot@npm:1.0.7"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    hasown: "npm:^2.0.0"
+    side-channel: "npm:^1.0.4"
+  checksum: 10/3e66720508831153ecf37d13def9f6856f9f2960989ec8a0a0476c98f887fca9eff0163127466485cb825c900c2d6fc601aa9117b7783b90ffce23a71ea5d053
   languageName: node
   linkType: hard
 
@@ -4695,10 +4020,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "ip@npm:2.0.1"
-  checksum: 10/d6dd154e1bc5e8725adfdd6fb92218635b9cbe6d873d051bd63b178f009777f751a5eea4c67021723a7056325fc3052f8b6599af0a2d56f042c93e684b4a0349
+"ip-address@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "ip-address@npm:9.0.5"
+  dependencies:
+    jsbn: "npm:1.1.0"
+    sprintf-js: "npm:^1.1.3"
+  checksum: 10/1ed81e06721af012306329b31f532b5e24e00cb537be18ddc905a84f19fe8f83a09a1699862bf3a1ec4b9dea93c55a3fa5faf8b5ea380431469df540f38b092c
+  languageName: node
+  linkType: hard
+
+"is-array-buffer@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "is-array-buffer@npm:3.0.4"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    get-intrinsic: "npm:^1.2.1"
+  checksum: 10/34a26213d981d58b30724ef37a1e0682f4040d580fa9ff58fdfdd3cefcb2287921718c63971c1c404951e7b747c50fdc7caf6e867e951353fa71b369c04c969b
   languageName: node
   linkType: hard
 
@@ -4709,26 +4047,56 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-callable@npm:^1.1.4, is-callable@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "is-callable@npm:1.2.2"
-  checksum: 10/364c0d2c2e0a802719906d527a42597865e2c2578204d82ea554bf38e11693c2449c4e6993ec17d6672b27ecf5748819109d6b6d7636346b3f90f55de213e794
+"is-bigint@npm:^1.0.1":
+  version: 1.0.4
+  resolution: "is-bigint@npm:1.0.4"
+  dependencies:
+    has-bigints: "npm:^1.0.1"
+  checksum: 10/cc981cf0564c503aaccc1e5f39e994ae16ae2d1a8fcd14721f14ad431809071f39ec568cfceef901cff408045f1a6d6bac90d1b43eeb0b8e3bc34c8eb1bdb4c4
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.2.0":
-  version: 2.4.0
-  resolution: "is-core-module@npm:2.4.0"
+"is-boolean-object@npm:^1.1.0":
+  version: 1.1.2
+  resolution: "is-boolean-object@npm:1.1.2"
   dependencies:
-    has: "npm:^1.0.3"
-  checksum: 10/9b0f05c4ee0246dfd24a0de5525f32e4cc06c057f787d129ab0a7a9aaa7578f19a825cf51a05e6cdd48b5c6a43f351cf577438f061ea70ac568133cdeb44cdbd
+    call-bind: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.0"
+  checksum: 10/ba794223b56a49a9f185e945eeeb6b7833b8ea52a335cec087d08196cf27b538940001615d3bb976511287cefe94e5907d55f00bb49580533f9ca9b4515fcc2e
+  languageName: node
+  linkType: hard
+
+"is-callable@npm:^1.1.3, is-callable@npm:^1.1.4, is-callable@npm:^1.2.7":
+  version: 1.2.7
+  resolution: "is-callable@npm:1.2.7"
+  checksum: 10/48a9297fb92c99e9df48706241a189da362bff3003354aea4048bd5f7b2eb0d823cd16d0a383cece3d76166ba16d85d9659165ac6fcce1ac12e6c649d66dbdb9
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.13.0":
+  version: 2.15.0
+  resolution: "is-core-module@npm:2.15.0"
+  dependencies:
+    hasown: "npm:^2.0.2"
+  checksum: 10/70e962543e5d3a97c07cb29144a86792d545a21f28e67da5401d85878a0193d46fbab8d97bc3ca680e2778705dca66e7b6ca840c493497a27ca0e8c5f3ac3d1d
+  languageName: node
+  linkType: hard
+
+"is-data-view@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-data-view@npm:1.0.1"
+  dependencies:
+    is-typed-array: "npm:^1.1.13"
+  checksum: 10/4ba4562ac2b2ec005fefe48269d6bd0152785458cd253c746154ffb8a8ab506a29d0cfb3b74af87513843776a88e4981ae25c89457bf640a33748eab1a7216b5
   languageName: node
   linkType: hard
 
 "is-date-object@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "is-date-object@npm:1.0.2"
-  checksum: 10/96c56c04631f866b3a3aea4b889eac6120c13d8a06dc7e105479ffd6f57e5ea3668f1d779ef30063d4b27aa8e9b235ea7d15bbdab54b056affc678c4769ff143
+  version: 1.0.5
+  resolution: "is-date-object@npm:1.0.5"
+  dependencies:
+    has-tostringtag: "npm:^1.0.0"
+  checksum: 10/cc80b3a4b42238fa0d358b9a6230dae40548b349e64a477cb7c5eff9b176ba194c11f8321daaf6dd157e44073e9b7fd01f87db1f14952a88d5657acdcd3a56e2
   languageName: node
   linkType: hard
 
@@ -4769,10 +4137,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-negative-zero@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "is-negative-zero@npm:2.0.0"
-  checksum: 10/44e7d27cbf4f09ee483d6d75a0f2f109f29ccd925874215c98cdc81b7677bc6642a4bbbce74fe142810fabcc11fc9f8787f9bb9b33a203f96a27b920daa2f51a
+"is-negative-zero@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "is-negative-zero@npm:2.0.3"
+  checksum: 10/8fe5cffd8d4fb2ec7b49d657e1691889778d037494c6f40f4d1a524cadd658b4b53ad7b6b73a59bcb4b143ae9a3d15829af864b2c0f9d65ac1e678c4c80f17e5
+  languageName: node
+  linkType: hard
+
+"is-number-object@npm:^1.0.4":
+  version: 1.0.7
+  resolution: "is-number-object@npm:1.0.7"
+  dependencies:
+    has-tostringtag: "npm:^1.0.0"
+  checksum: 10/8700dcf7f602e0a9625830541345b8615d04953655acbf5c6d379c58eb1af1465e71227e95d501343346e1d49b6f2d53cbc166b1fc686a7ec19151272df582f9
   languageName: node
   linkType: hard
 
@@ -4799,28 +4176,72 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-regex@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "is-regex@npm:1.1.1"
+"is-regex@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "is-regex@npm:1.1.4"
   dependencies:
-    has-symbols: "npm:^1.0.1"
-  checksum: 10/1ed55cadc258a4fb88fb44e74e1825cb81ad8ffba83ea03e18125ed6c3c6054d0799cabdb67445d0bdfd568a99f629656a1ab67862ea0c099fd641d49f9fb244
+    call-bind: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.0"
+  checksum: 10/36d9174d16d520b489a5e9001d7d8d8624103b387be300c50f860d9414556d0485d74a612fdafc6ebbd5c89213d947dcc6b6bff6b2312093f71ea03cbb19e564
+  languageName: node
+  linkType: hard
+
+"is-shared-array-buffer@npm:^1.0.2, is-shared-array-buffer@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "is-shared-array-buffer@npm:1.0.3"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+  checksum: 10/bc5402900dc62b96ebb2548bf5b0a0bcfacc2db122236fe3ab3b3e3c884293a0d5eb777e73f059bcbf8dc8563bb65eae972fee0fb97e38a9ae27c8678f62bcfe
   languageName: node
   linkType: hard
 
 "is-stream@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "is-stream@npm:2.0.0"
-  checksum: 10/4dc47738e26bc4f1b3be9070b6b9e39631144f204fc6f87db56961220add87c10a999ba26cf81699f9ef9610426f69cb08a4713feff8deb7d8cadac907826935
+  version: 2.0.1
+  resolution: "is-stream@npm:2.0.1"
+  checksum: 10/b8e05ccdf96ac330ea83c12450304d4a591f9958c11fd17bed240af8d5ffe08aedafa4c0f4cfccd4d28dc9d4d129daca1023633d5c11601a6cbc77521f6fae66
   languageName: node
   linkType: hard
 
-"is-symbol@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "is-symbol@npm:1.0.3"
+"is-string@npm:^1.0.5, is-string@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "is-string@npm:1.0.7"
   dependencies:
-    has-symbols: "npm:^1.0.1"
-  checksum: 10/4854604be4abb5f9d885d4bbc9f9318b7dbda9402fbe172c09861bb8910d97e70fac6dabbf1023a7ec56986f457c92abb08f1c99decce83c06c944130a0b1cd1
+    has-tostringtag: "npm:^1.0.0"
+  checksum: 10/2bc292fe927493fb6dfc3338c099c3efdc41f635727c6ebccf704aeb2a27bca7acb9ce6fd34d103db78692b10b22111a8891de26e12bfa1c5e11e263c99d1fef
+  languageName: node
+  linkType: hard
+
+"is-symbol@npm:^1.0.2, is-symbol@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "is-symbol@npm:1.0.4"
+  dependencies:
+    has-symbols: "npm:^1.0.2"
+  checksum: 10/a47dd899a84322528b71318a89db25c7ecdec73197182dad291df15ffea501e17e3c92c8de0bfb50e63402747399981a687b31c519971b1fa1a27413612be929
+  languageName: node
+  linkType: hard
+
+"is-typed-array@npm:^1.1.13":
+  version: 1.1.13
+  resolution: "is-typed-array@npm:1.1.13"
+  dependencies:
+    which-typed-array: "npm:^1.1.14"
+  checksum: 10/f850ba08286358b9a11aee6d93d371a45e3c59b5953549ee1c1a9a55ba5c1dd1bd9952488ae194ad8f32a9cf5e79c8fa5f0cc4d78c00720aa0bbcf238b38062d
+  languageName: node
+  linkType: hard
+
+"is-weakref@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "is-weakref@npm:1.0.2"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+  checksum: 10/0023fd0e4bdf9c338438ffbe1eed7ebbbff7e7e18fb7cdc227caaf9d4bd024a2dcdf6a8c9f40c92192022eac8391243bb9e66cccebecbf6fe1d8a366108f8513
+  languageName: node
+  linkType: hard
+
+"isarray@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "isarray@npm:2.0.5"
+  checksum: 10/1d8bc7911e13bb9f105b1b3e0b396c787a9e63046af0b8fe0ab1414488ab06b2b099b87a2d8a9e31d21c9a6fad773c7fc8b257c4880f2d957274479d28ca3414
   languageName: node
   linkType: hard
 
@@ -4831,6 +4252,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isexe@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "isexe@npm:3.1.1"
+  checksum: 10/7fe1931ee4e88eb5aa524cd3ceb8c882537bc3a81b02e438b240e47012eef49c86904d0f0e593ea7c3a9996d18d0f1f3be8d3eaa92333977b0c3a9d353d5563e
+  languageName: node
+  linkType: hard
+
 "isobject@npm:^3.0.1":
   version: 3.0.1
   resolution: "isobject@npm:3.0.1"
@@ -4838,30 +4266,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-coverage@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "istanbul-lib-coverage@npm:3.0.0"
-  checksum: 10/eb0ba205890ee02ea9d76b31d6adf196f532b28a158c0c4db0db6ee6b60de476aca7bba34a9321d17fc396853db758d9430f1202ed28a7a6060e9d1cc8f555c0
-  languageName: node
-  linkType: hard
-
-"istanbul-lib-coverage@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "istanbul-lib-coverage@npm:3.2.0"
-  checksum: 10/31621b84ad29339242b63d454243f558a7958ee0b5177749bacf1f74be7d95d3fd93853738ef7eebcddfaf3eab014716e51392a8dbd5aa1bdc1b15c2ebc53c24
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
+  version: 3.2.2
+  resolution: "istanbul-lib-coverage@npm:3.2.2"
+  checksum: 10/40bbdd1e937dfd8c830fa286d0f665e81b7a78bdabcd4565f6d5667c99828bda3db7fb7ac6b96a3e2e8a2461ddbc5452d9f8bc7d00cb00075fa6a3e99f5b6a81
   languageName: node
   linkType: hard
 
 "istanbul-lib-instrument@npm:^5.0.4":
-  version: 5.1.0
-  resolution: "istanbul-lib-instrument@npm:5.1.0"
+  version: 5.2.1
+  resolution: "istanbul-lib-instrument@npm:5.2.1"
   dependencies:
     "@babel/core": "npm:^7.12.3"
     "@babel/parser": "npm:^7.14.7"
     "@istanbuljs/schema": "npm:^0.1.2"
     istanbul-lib-coverage: "npm:^3.2.0"
     semver: "npm:^6.3.0"
-  checksum: 10/7447ba3f8049f331d5b4a1c450183e88c2fdad044149ad0d9830f71bc8da90d841c393b830bc33237ae75122c3b0e03ca845701873d6c51690bc25caa1f13a94
+  checksum: 10/bbc4496c2f304d799f8ec22202ab38c010ac265c441947f075c0f7d46bd440b45c00e46017cf9053453d42182d768b1d6ed0e70a142c95ab00df9843aa5ab80e
   languageName: node
   linkType: hard
 
@@ -4879,34 +4300,47 @@ __metadata:
   linkType: hard
 
 "istanbul-lib-report@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "istanbul-lib-report@npm:3.0.0"
+  version: 3.0.1
+  resolution: "istanbul-lib-report@npm:3.0.1"
   dependencies:
     istanbul-lib-coverage: "npm:^3.0.0"
-    make-dir: "npm:^3.0.0"
+    make-dir: "npm:^4.0.0"
     supports-color: "npm:^7.1.0"
-  checksum: 10/06b37952e9cb0fe419a37c7f3d74612a098167a9eb0e5264228036e78b42ca5226501e8130738b5306d94bae2ea068ca674080d4af959992523d84aacff67728
+  checksum: 10/86a83421ca1cf2109a9f6d193c06c31ef04a45e72a74579b11060b1e7bb9b6337a4e6f04abfb8857e2d569c271273c65e855ee429376a0d7c91ad91db42accd1
   languageName: node
   linkType: hard
 
 "istanbul-lib-source-maps@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "istanbul-lib-source-maps@npm:4.0.0"
+  version: 4.0.1
+  resolution: "istanbul-lib-source-maps@npm:4.0.1"
   dependencies:
     debug: "npm:^4.1.1"
     istanbul-lib-coverage: "npm:^3.0.0"
     source-map: "npm:^0.6.1"
-  checksum: 10/765252abc6b5c9d29905fc97ce04b92da87d198f2c0161e62fe0aac8bb74fb7bd472a5e1d90fe3e78723d8cad43913f08d8eefa0339536fcc33b3a1922cf5fc3
+  checksum: 10/5526983462799aced011d776af166e350191b816821ea7bcf71cab3e5272657b062c47dc30697a22a43656e3ced78893a42de677f9ccf276a28c913190953b82
   languageName: node
   linkType: hard
 
 "istanbul-reports@npm:^3.1.3":
-  version: 3.1.4
-  resolution: "istanbul-reports@npm:3.1.4"
+  version: 3.1.7
+  resolution: "istanbul-reports@npm:3.1.7"
   dependencies:
     html-escaper: "npm:^2.0.0"
     istanbul-lib-report: "npm:^3.0.0"
-  checksum: 10/b720f7ff87a37e1500e001913e781395b96cc6ca4d475e01da2ec78d1571435ded4b1b31fb53ef8d760bc5fa691b2b6b647bcb4c1238f6aaf58b261d47510c93
+  checksum: 10/f1faaa4684efaf57d64087776018d7426312a59aa6eeb4e0e3a777347d23cd286ad18f427e98f0e3dee666103d7404c9d7abc5f240406a912fa16bd6695437fa
+  languageName: node
+  linkType: hard
+
+"jackspeak@npm:^3.1.2":
+  version: 3.4.3
+  resolution: "jackspeak@npm:3.4.3"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+    "@pkgjs/parseargs": "npm:^0.11.0"
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 10/96f8786eaab98e4bf5b2a5d6d9588ea46c4d06bbc4f2eb861fdd7b6b182b16f71d8a70e79820f335d52653b16d4843b29dd9cdcf38ae80406756db9199497cf3
   languageName: node
   linkType: hard
 
@@ -5142,14 +4576,14 @@ __metadata:
   linkType: hard
 
 "jest-pnp-resolver@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "jest-pnp-resolver@npm:1.2.2"
+  version: 1.2.3
+  resolution: "jest-pnp-resolver@npm:1.2.3"
   peerDependencies:
     jest-resolve: "*"
   peerDependenciesMeta:
     jest-resolve:
       optional: true
-  checksum: 10/bd85dcc0e76e0eb0c3d56382ec140f08d25ff4068cda9d0e360bb78fb176cb726d0beab82dc0e8694cafd09f55fee7622b8bcb240afa5fad301f4ed3eebb4f47
+  checksum: 10/db1a8ab2cb97ca19c01b1cfa9a9c8c69a143fde833c14df1fab0766f411b1148ff0df878adea09007ac6a2085ec116ba9a996a6ad104b1e58c20adbf88eed9b2
   languageName: node
   linkType: hard
 
@@ -5357,14 +4791,14 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1":
-  version: 3.14.0
-  resolution: "js-yaml@npm:3.14.0"
+  version: 3.14.1
+  resolution: "js-yaml@npm:3.14.1"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/88c96664ed27db929fa046f4e6d1f1cbcab4372379c77af68e8d56ada9ff59566528c053f83260c4e23bd348fc430814ed3637e4b809e1d32b795c74b5d15638
+  checksum: 10/9e22d80b4d0105b9899135365f746d47466ed53ef4223c529b3c0f7a39907743fdbd3c4379f94f1106f02755b5e90b2faaf84801a891135544e1ea475d1a1379
   languageName: node
   linkType: hard
 
@@ -5376,6 +4810,13 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10/c138a34a3fd0d08ebaf71273ad4465569a483b8a639e0b118ff65698d257c2791d3199e3f303631f2cb98213fa7b5f5d6a4621fd0fff819421b990d30d967140
+  languageName: node
+  linkType: hard
+
+"jsbn@npm:1.1.0":
+  version: 1.1.0
+  resolution: "jsbn@npm:1.1.0"
+  checksum: 10/bebe7ae829bbd586ce8cbe83501dd8cb8c282c8902a8aeeed0a073a89dc37e8103b1244f3c6acd60278bcbfe12d93a3f83c9ac396868a3b3bbc3c5e5e3b648ef
   languageName: node
   linkType: hard
 
@@ -5422,26 +4863,6 @@ __metadata:
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
   checksum: 10/12786c2e2f22c27439e6db0532ba321f1d0617c27ad8cb1c352a0e9249a50182fd1ba8b52a18899291604b0c32eafa8afd09e51203f19109a0537f68db2b652d
-  languageName: node
-  linkType: hard
-
-"json5@npm:^2.1.2":
-  version: 2.1.3
-  resolution: "json5@npm:2.1.3"
-  dependencies:
-    minimist: "npm:^1.2.5"
-  bin:
-    json5: lib/cli.js
-  checksum: 10/ba3f0d81567a2d51728a11a4d2a7e7a894981b2279b39d1bceed9976dbc9d2d25bd54dbafc44f4eddc73f63fa28bd904a325252c25683d309d832f5f5edc7196
-  languageName: node
-  linkType: hard
-
-"json5@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "json5@npm:2.2.1"
-  bin:
-    json5: lib/cli.js
-  checksum: 10/ee31060b929fbfdc3c80288286e4403ed95f47d9fe2d29f46c833b8cd4ec98b2cdb3537e2c0f15846db90950ae70bc01d2aaae3c303d70523e8039cf0e810cf5
   languageName: node
   linkType: hard
 
@@ -5495,9 +4916,9 @@ __metadata:
   linkType: hard
 
 "lines-and-columns@npm:^1.1.6":
-  version: 1.1.6
-  resolution: "lines-and-columns@npm:1.1.6"
-  checksum: 10/198a5436b1fa5cf703bae719c01c686b076f0ad7e1aafd95a58d626cabff302dc0414822126f2f80b58a8c3d66cda8a7b6da064f27130f87e1d3506d6dfd0d68
+  version: 1.2.4
+  resolution: "lines-and-columns@npm:1.2.4"
+  checksum: 10/0c37f9f7fa212b38912b7145e1cd16a5f3cd34d782441c3e6ca653485d326f58b3caccda66efce1c5812bde4961bbde3374fae4b0d11bf1226152337f3894aa5
   languageName: node
   linkType: hard
 
@@ -5543,28 +4964,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0":
+  version: 10.4.3
+  resolution: "lru-cache@npm:10.4.3"
+  checksum: 10/e6e90267360476720fa8e83cc168aa2bf0311f3f2eea20a6ba78b90a885ae72071d9db132f40fda4129c803e7dcec3a6b6a6fbb44ca90b081630b810b5d6a41a
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10/951d2673dcc64a7fb888bf3d13bc2fdf923faca97d89cdb405ba3dfff77e2b26e5798d405e78fcd7094c9e7b8b4dab2ddc5a4f8a11928af24a207b7c738ca3f8
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "lru-cache@npm:6.0.0"
-  dependencies:
-    yallist: "npm:^4.0.0"
-  checksum: 10/fc1fe2ee205f7c8855fa0f34c1ab0bcf14b6229e35579ec1fd1079f31d6fc8ef8eb6fd17f2f4d99788d7e339f50e047555551ebd5e434dda503696e7c6591825
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^7.7.1":
-  version: 7.18.3
-  resolution: "lru-cache@npm:7.18.3"
-  checksum: 10/6029ca5aba3aacb554e919d7ef804fffd4adfc4c83db00fac8248c7c78811fb6d4b6f70f7fd9d55032b3823446546a007edaa66ad1f2377ae833bd983fac5d98
   languageName: node
   linkType: hard
 
@@ -5578,36 +4990,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-dir@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "make-dir@npm:3.1.0"
+"make-dir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "make-dir@npm:4.0.0"
   dependencies:
-    semver: "npm:^6.0.0"
-  checksum: 10/484200020ab5a1fdf12f393fe5f385fc8e4378824c940fba1729dcd198ae4ff24867bc7a5646331e50cead8abff5d9270c456314386e629acec6dff4b8016b78
+    semver: "npm:^7.5.3"
+  checksum: 10/bf0731a2dd3aab4db6f3de1585cea0b746bb73eb5a02e3d8d72757e376e64e6ada190b1eddcde5b2f24a81b688a9897efd5018737d05e02e2a671dda9cff8a8a
   languageName: node
   linkType: hard
 
-"make-fetch-happen@npm:^10.0.3":
-  version: 10.2.1
-  resolution: "make-fetch-happen@npm:10.2.1"
+"make-fetch-happen@npm:^13.0.0":
+  version: 13.0.1
+  resolution: "make-fetch-happen@npm:13.0.1"
   dependencies:
-    agentkeepalive: "npm:^4.2.1"
-    cacache: "npm:^16.1.0"
-    http-cache-semantics: "npm:^4.1.0"
-    http-proxy-agent: "npm:^5.0.0"
-    https-proxy-agent: "npm:^5.0.0"
+    "@npmcli/agent": "npm:^2.0.0"
+    cacache: "npm:^18.0.0"
+    http-cache-semantics: "npm:^4.1.1"
     is-lambda: "npm:^1.0.1"
-    lru-cache: "npm:^7.7.1"
-    minipass: "npm:^3.1.6"
-    minipass-collect: "npm:^1.0.2"
-    minipass-fetch: "npm:^2.0.3"
+    minipass: "npm:^7.0.2"
+    minipass-fetch: "npm:^3.0.0"
     minipass-flush: "npm:^1.0.5"
     minipass-pipeline: "npm:^1.2.4"
     negotiator: "npm:^0.6.3"
+    proc-log: "npm:^4.2.0"
     promise-retry: "npm:^2.0.1"
-    socks-proxy-agent: "npm:^7.0.0"
-    ssri: "npm:^9.0.0"
-  checksum: 10/fef5acb865a46f25ad0b5ad7d979799125db5dbb24ea811ffa850fbb804bc8e495df2237a8ec3a4fc6250e73c2f95549cca6d6d36a73b1faa61224504eb1188f
+    ssri: "npm:^10.0.0"
+  checksum: 10/11bae5ad6ac59b654dbd854f30782f9de052186c429dfce308eda42374528185a100ee40ac9ffdc36a2b6c821ecaba43913e4730a12f06f15e895ea9cb23fa59
   languageName: node
   linkType: hard
 
@@ -5635,12 +5043,12 @@ __metadata:
   linkType: hard
 
 "micromatch@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "micromatch@npm:4.0.4"
+  version: 4.0.7
+  resolution: "micromatch@npm:4.0.7"
   dependencies:
-    braces: "npm:^3.0.1"
-    picomatch: "npm:^2.2.3"
-  checksum: 10/c499da5aad38f3ba1a32a73a81f3dd9b631e12492133c503c14ce59aa5c631159c08f2c43d3a7e0ea3955c7921d41b7b97e662360fe3b28b2cfb0923949c176d
+    braces: "npm:^3.0.3"
+    picomatch: "npm:^2.3.1"
+  checksum: 10/a11ed1cb67dcbbe9a5fc02c4062cf8bb0157d73bf86956003af8dcfdf9b287f9e15ec0f6d6925ff6b8b5b496202335e497b01de4d95ef6cf06411bc5e5c474a0
   languageName: node
   linkType: hard
 
@@ -5651,21 +5059,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.4, minimatch@npm:^3.1.2":
+"minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
     brace-expansion: "npm:^1.1.7"
   checksum: 10/e0b25b04cd4ec6732830344e5739b13f8690f8a012d73445a4a19fbc623f5dd481ef7a5827fde25954cd6026fede7574cc54dc4643c99d6c6b653d6203f94634
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^5.0.1":
-  version: 5.1.6
-  resolution: "minimatch@npm:5.1.6"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/126b36485b821daf96d33b5c821dac600cc1ab36c87e7a532594f9b1652b1fa89a1eebcaad4dff17c764dce1a7ac1531327f190fed5f97d8f6e5f889c116c429
   languageName: node
   linkType: hard
 
@@ -5678,34 +5077,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.5":
-  version: 1.2.6
-  resolution: "minimist@npm:1.2.6"
-  checksum: 10/b956a7d48669c5007f0afce100a92d3af18e77939a25b5b4f62e9ea07c2777033608327e14c2af85684d5cd504f623f2a04d30a4a43379d21dd3c6dcf12b8ab8
-  languageName: node
-  linkType: hard
-
-"minipass-collect@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "minipass-collect@npm:1.0.2"
+"minipass-collect@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "minipass-collect@npm:2.0.1"
   dependencies:
-    minipass: "npm:^3.0.0"
-  checksum: 10/14df761028f3e47293aee72888f2657695ec66bd7d09cae7ad558da30415fdc4752bbfee66287dcc6fd5e6a2fa3466d6c484dc1cbd986525d9393b9523d97f10
+    minipass: "npm:^7.0.3"
+  checksum: 10/b251bceea62090f67a6cced7a446a36f4cd61ee2d5cea9aee7fff79ba8030e416327a1c5aa2908dc22629d06214b46d88fdab8c51ac76bacbf5703851b5ad342
   languageName: node
   linkType: hard
 
-"minipass-fetch@npm:^2.0.3":
-  version: 2.1.2
-  resolution: "minipass-fetch@npm:2.1.2"
+"minipass-fetch@npm:^3.0.0":
+  version: 3.0.5
+  resolution: "minipass-fetch@npm:3.0.5"
   dependencies:
     encoding: "npm:^0.1.13"
-    minipass: "npm:^3.1.6"
+    minipass: "npm:^7.0.3"
     minipass-sized: "npm:^1.0.3"
     minizlib: "npm:^2.1.2"
   dependenciesMeta:
     encoding:
       optional: true
-  checksum: 10/8cfc589563ae2a11eebbf79121ef9a526fd078fca949ed3f1e4a51472ca4a4aad89fcea1738982ce9d7d833116ecc9c6ae9ebbd844832a94e3f4a3d4d1b9d3b9
+  checksum: 10/c669948bec1373313aaa8f104b962a3ced9f45c49b26366a4b0ae27ccdfa9c5740d72c8a84d3f8623d7a61c5fc7afdfda44789008c078f61a62441142efc4a97
   languageName: node
   linkType: hard
 
@@ -5736,7 +5128,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^3.0.0, minipass@npm:^3.1.1, minipass@npm:^3.1.6":
+"minipass@npm:^3.0.0":
   version: 3.3.6
   resolution: "minipass@npm:3.3.6"
   dependencies:
@@ -5752,6 +5144,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "minipass@npm:7.1.2"
+  checksum: 10/c25f0ee8196d8e6036661104bacd743785b2599a21de5c516b32b3fa2b83113ac89a2358465bc04956baab37ffb956ae43be679b2262bf7be15fce467ccd7950
+  languageName: node
+  linkType: hard
+
 "minizlib@npm:^2.1.1, minizlib@npm:^2.1.2":
   version: 2.1.2
   resolution: "minizlib@npm:2.1.2"
@@ -5762,7 +5161,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^1.0.3, mkdirp@npm:^1.0.4":
+"mkdirp@npm:^1.0.3":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
   bin:
@@ -5775,13 +5174,6 @@ __metadata:
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
   checksum: 10/673cdb2c3133eb050c745908d8ce632ed2c02d85640e2edb3ace856a2266a813b30c613569bf3354fdf4ea7d1a1494add3bfa95e2713baa27d0c2c71fc44f58f
-  languageName: node
-  linkType: hard
-
-"ms@npm:^2.0.0":
-  version: 2.1.3
-  resolution: "ms@npm:2.1.3"
-  checksum: 10/aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
   languageName: node
   linkType: hard
 
@@ -5810,22 +5202,22 @@ __metadata:
   linkType: hard
 
 "node-gyp@npm:latest":
-  version: 9.3.1
-  resolution: "node-gyp@npm:9.3.1"
+  version: 10.2.0
+  resolution: "node-gyp@npm:10.2.0"
   dependencies:
     env-paths: "npm:^2.2.0"
-    glob: "npm:^7.1.4"
+    exponential-backoff: "npm:^3.1.1"
+    glob: "npm:^10.3.10"
     graceful-fs: "npm:^4.2.6"
-    make-fetch-happen: "npm:^10.0.3"
-    nopt: "npm:^6.0.0"
-    npmlog: "npm:^6.0.0"
-    rimraf: "npm:^3.0.2"
+    make-fetch-happen: "npm:^13.0.0"
+    nopt: "npm:^7.0.0"
+    proc-log: "npm:^4.1.0"
     semver: "npm:^7.3.5"
-    tar: "npm:^6.1.2"
-    which: "npm:^2.0.2"
+    tar: "npm:^6.2.1"
+    which: "npm:^4.0.0"
   bin:
     node-gyp: bin/node-gyp.js
-  checksum: 10/e9345b22be0a3256af87a16ba9604362cd8e4db304e67e71dd83bb8e573f3fdbaf69e359b5af572a14a98730cc3e1813679444ee029093d2a2f38ba3cac4ed7e
+  checksum: 10/41773093b1275751dec942b985982fd4e7a69b88cae719b868babcef3880ee6168aaec8dcaa8cd0b9fa7c84873e36cc549c6cac6a124ee65ba4ce1f1cc108cfe
   languageName: node
   linkType: hard
 
@@ -5836,13 +5228,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "node-releases@npm:2.0.1"
-  checksum: 10/b20dd8d4bced11f75060f0387e05e76b9dc4a0451f7bb3516eade6f50499ea7768ba95d8a60d520c193402df1e58cb3fe301510cc1c1ad68949c3d57b5149866
-  languageName: node
-  linkType: hard
-
 "node-releases@npm:^2.0.14":
   version: 2.0.18
   resolution: "node-releases@npm:2.0.18"
@@ -5850,21 +5235,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.3":
-  version: 2.0.4
-  resolution: "node-releases@npm:2.0.4"
-  checksum: 10/b32d6c2032c7b169ae3938b416fc50f123f5bd577d54a79b2ae201febf27b22846b01c803dd35ac8689afe840f8ba4e5f7154723db629b80f359836b6707b92f
-  languageName: node
-  linkType: hard
-
-"nopt@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "nopt@npm:6.0.0"
+"nopt@npm:^7.0.0":
+  version: 7.2.1
+  resolution: "nopt@npm:7.2.1"
   dependencies:
-    abbrev: "npm:^1.0.0"
+    abbrev: "npm:^2.0.0"
   bin:
     nopt: bin/nopt.js
-  checksum: 10/3c1128e07cd0241ae66d6e6a472170baa9f3e84dd4203950ba8df5bafac4efa2166ce917a57ef02b01ba7c40d18b2cc64b29b225fd3640791fe07b24f0b33a32
+  checksum: 10/95a1f6dec8a81cd18cdc2fed93e6f0b4e02cf6bdb4501c848752c6e34f9883d9942f036a5e3b21a699047d8a448562d891e67492df68ec9c373e6198133337ae
   languageName: node
   linkType: hard
 
@@ -5884,51 +5262,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npmlog@npm:^6.0.0":
-  version: 6.0.2
-  resolution: "npmlog@npm:6.0.2"
-  dependencies:
-    are-we-there-yet: "npm:^3.0.0"
-    console-control-strings: "npm:^1.1.0"
-    gauge: "npm:^4.0.3"
-    set-blocking: "npm:^2.0.0"
-  checksum: 10/82b123677e62deb9e7472e27b92386c09e6e254ee6c8bcd720b3011013e4168bc7088e984f4fbd53cb6e12f8b4690e23e4fa6132689313e0d0dc4feea45489bb
+"object-inspect@npm:^1.13.1":
+  version: 1.13.2
+  resolution: "object-inspect@npm:1.13.2"
+  checksum: 10/7ef65583b6397570a17c56f0c1841e0920e83900f2c94638927abb7b81ac08a19c7aae135bd9dcca96208cac0c7332b4650fb927f027b0cf92d71df2990d0561
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.8.0":
-  version: 1.8.0
-  resolution: "object-inspect@npm:1.8.0"
-  checksum: 10/065e1b3e10d8bf57b0b7a9eaa949df92762a1e53af2ef799194dd974515a08de9d14c5923cb61ec5bad47663a0e26f6115294c7f976a9237eef6b086e72bf9b1
-  languageName: node
-  linkType: hard
-
-"object-keys@npm:^1.0.12, object-keys@npm:^1.1.1":
+"object-keys@npm:^1.1.1":
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
   checksum: 10/3d81d02674115973df0b7117628ea4110d56042e5326413e4b4313f0bcdf7dd78d4a3acef2c831463fa3796a66762c49daef306f4a0ea1af44877d7086d73bde
   languageName: node
   linkType: hard
 
-"object.assign@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "object.assign@npm:4.1.1"
+"object.assign@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "object.assign@npm:4.1.5"
   dependencies:
-    define-properties: "npm:^1.1.3"
-    es-abstract: "npm:^1.18.0-next.0"
-    has-symbols: "npm:^1.0.1"
+    call-bind: "npm:^1.0.5"
+    define-properties: "npm:^1.2.1"
+    has-symbols: "npm:^1.0.3"
     object-keys: "npm:^1.1.1"
-  checksum: 10/a622ec267e75e6e880834c6b94b02bd40eaf9bed668ff5a92137ec8389c73168f256d9bcac8735b6c8b0ed2546ccf09b85917e6d4ad1d21fa8204045ce81e624
+  checksum: 10/dbb22da4cda82e1658349ea62b80815f587b47131b3dd7a4ab7f84190ab31d206bbd8fe7e26ae3220c55b65725ac4529825f6142154211220302aa6b1518045d
   languageName: node
   linkType: hard
 
 "object.getownpropertydescriptors@npm:^2.0.3":
-  version: 2.1.0
-  resolution: "object.getownpropertydescriptors@npm:2.1.0"
+  version: 2.1.8
+  resolution: "object.getownpropertydescriptors@npm:2.1.8"
   dependencies:
-    define-properties: "npm:^1.1.3"
-    es-abstract: "npm:^1.17.0-next.1"
-  checksum: 10/ec6b4b3d0c21397aabbb02222fa134aaa6a56978933c80d5b3f3fdd7e2e567350be3b3a0805b1056f97a5dea55b3100a121f3262d1c13ddba5da4351c117ae4b
+    array.prototype.reduce: "npm:^1.0.6"
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.2"
+    es-object-atoms: "npm:^1.0.0"
+    gopd: "npm:^1.0.1"
+    safe-array-concat: "npm:^1.1.2"
+  checksum: 10/8c50f52e0d702d30836f3d2772ba02807ca25a5381be6f9470c6d143ee0bad01bce3fff0fedea2bdbc0c9297e4eb7785ffee5739f6a3a7c60fcd622b42f8a9fb
   languageName: node
   linkType: hard
 
@@ -5951,16 +5322,16 @@ __metadata:
   linkType: hard
 
 "optionator@npm:^0.9.3":
-  version: 0.9.3
-  resolution: "optionator@npm:0.9.3"
+  version: 0.9.4
+  resolution: "optionator@npm:0.9.4"
   dependencies:
-    "@aashutoshrathi/word-wrap": "npm:^1.2.3"
     deep-is: "npm:^0.1.3"
     fast-levenshtein: "npm:^2.0.6"
     levn: "npm:^0.4.1"
     prelude-ls: "npm:^1.2.1"
     type-check: "npm:^0.4.0"
-  checksum: 10/fa28d3016395974f7fc087d6bbf0ac7f58ac3489f4f202a377e9c194969f329a7b88c75f8152b33fb08794a30dcd5c079db6bb465c28151357f113d80bbf67da
+    word-wrap: "npm:^1.2.5"
+  checksum: 10/a8398559c60aef88d7f353a4f98dcdff6090a4e70f874c827302bf1213d9106a1c4d5fcb68dacb1feb3c30a04c4102f41047aa55d4c576b863d6fc876e001af6
   languageName: node
   linkType: hard
 
@@ -6025,6 +5396,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "package-json-from-dist@npm:1.0.0"
+  checksum: 10/ac706ec856a5a03f5261e4e48fa974f24feb044d51f84f8332e2af0af04fbdbdd5bbbfb9cbbe354190409bc8307c83a9e38c6672c3c8855f709afb0006a009ea
+  languageName: node
+  linkType: hard
+
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -6081,10 +5459,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-parse@npm:^1.0.6":
+"path-parse@npm:^1.0.7":
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 10/49abf3d81115642938a8700ec580da6e830dde670be21893c62f4e10bd7dd4c3742ddc603fe24f898cba7eb0c6bc1777f8d9ac14185d34540c6d4d80cd9cae8a
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^1.11.1":
+  version: 1.11.1
+  resolution: "path-scurry@npm:1.11.1"
+  dependencies:
+    lru-cache: "npm:^10.2.0"
+    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
+  checksum: 10/5e8845c159261adda6f09814d7725683257fcc85a18f329880ab4d7cc1d12830967eae5d5894e453f341710d5484b8fdbbd4d75181b4d6e1eb2f4dc7aeadc434
   languageName: node
   linkType: hard
 
@@ -6095,28 +5483,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "picocolors@npm:1.0.0"
-  checksum: 10/a2e8092dd86c8396bdba9f2b5481032848525b3dc295ce9b57896f931e63fc16f79805144321f72976383fc249584672a75cc18d6777c6b757603f372f745981
-  languageName: node
-  linkType: hard
-
-"picocolors@npm:^1.0.1":
+"picocolors@npm:^1.0.0, picocolors@npm:^1.0.1":
   version: 1.0.1
   resolution: "picocolors@npm:1.0.1"
   checksum: 10/fa68166d1f56009fc02a34cdfd112b0dd3cf1ef57667ac57281f714065558c01828cdf4f18600ad6851cbe0093952ed0660b1e0156bddf2184b6aaf5817553a5
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4":
-  version: 2.2.2
-  resolution: "picomatch@npm:2.2.2"
-  checksum: 10/9f645f6dd4292e6a2752659f5e09799b41069da0c965e260c0f64d47c331dd879c9469d73eeddba61409b7f383a46397129cd6340576a8584eee35247031773a
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^2.2.3":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10/60c2595003b05e4535394d1da94850f5372c9427ca4413b71210f437f7b2ca091dbd611c45e8b37d10036fa8eade25c1b8951654f9d3973bfa66a2ff4d3b08bc
@@ -6130,14 +5504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.4":
-  version: 4.0.5
-  resolution: "pirates@npm:4.0.5"
-  checksum: 10/3728bae0cf6c18c3d25f5449ee8c5bc1a6a83bca688abe0e1654ce8c069bfd408170397cef133ed9ec8b0faeb4093c5c728d0e72ab7b3385256cd87008c40364
-  languageName: node
-  linkType: hard
-
-"pirates@npm:^4.0.6":
+"pirates@npm:^4.0.4, pirates@npm:^4.0.6":
   version: 4.0.6
   resolution: "pirates@npm:4.0.6"
   checksum: 10/d02dda76f4fec1cbdf395c36c11cf26f76a644f9f9a1bfa84d3167d0d3154d5289aacc72677aa20d599bb4a6937a471de1b65c995e2aea2d8687cbcd7e43ea5f
@@ -6159,6 +5526,13 @@ __metadata:
   dependencies:
     find-up: "npm:^4.0.0"
   checksum: 10/9863e3f35132bf99ae1636d31ff1e1e3501251d480336edb1c211133c8d58906bed80f154a1d723652df1fda91e01c7442c2eeaf9dc83157c7ae89087e43c8d6
+  languageName: node
+  linkType: hard
+
+"possible-typed-array-names@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "possible-typed-array-names@npm:1.0.0"
+  checksum: 10/8ed3e96dfeea1c5880c1f4c9cb707e5fb26e8be22f14f82ef92df20fd2004e635c62ba47fbe8f2bb63bfd80dac1474be2fb39798da8c2feba2815435d1f749af
   languageName: node
   linkType: hard
 
@@ -6189,10 +5563,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"promise-inflight@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "promise-inflight@npm:1.0.1"
-  checksum: 10/1560d413ea20c5a74f3631d39ba8cbd1972b9228072a755d01e1f5ca5110382d9af76a1582d889445adc6e75bb5ac4886b56dc4b6eae51b30145d7bb1ac7505b
+"proc-log@npm:^4.1.0, proc-log@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "proc-log@npm:4.2.0"
+  checksum: 10/4e1394491b717f6c1ade15c570ecd4c2b681698474d3ae2d303c1e4b6ab9455bd5a81566211e82890d5a5ae9859718cc6954d5150bb18b09b72ecb297beae90a
   languageName: node
   linkType: hard
 
@@ -6207,44 +5581,40 @@ __metadata:
   linkType: hard
 
 "prompts@npm:^2.0.1":
-  version: 2.3.2
-  resolution: "prompts@npm:2.3.2"
+  version: 2.4.2
+  resolution: "prompts@npm:2.4.2"
   dependencies:
     kleur: "npm:^3.0.3"
-    sisteransi: "npm:^1.0.4"
-  checksum: 10/a6e01ac776353010053efa91100d2ec61b6db2d145cc91b1b89871be194c7dde90341b31ba87a0c243920ae99cc8f6fc98e57ac4c529ec41f6850cbeef7d142c
+    sisteransi: "npm:^1.0.5"
+  checksum: 10/c52536521a4d21eff4f2f2aa4572446cad227464066365a7167e52ccf8d9839c099f9afec1aba0eed3d5a2514b3e79e0b3e7a1dc326b9acde6b75d27ed74b1a9
   languageName: node
   linkType: hard
 
 "punycode@npm:^2.1.0":
-  version: 2.1.1
-  resolution: "punycode@npm:2.1.1"
-  checksum: 10/939daa010c2cacebdb060c40ecb52fef0a739324a66f7fffe0f94353a1ee83e3b455e9032054c4a0c4977b0a28e27086f2171c392832b59a01bd948fd8e20914
+  version: 2.3.1
+  resolution: "punycode@npm:2.3.1"
+  checksum: 10/febdc4362bead22f9e2608ff0171713230b57aff9dddc1c273aa2a651fbd366f94b7d6a71d78342a7c0819906750351ca7f2edd26ea41b626d87d6a13d1bd059
   languageName: node
   linkType: hard
 
 "pure-rand@npm:^6.0.0":
-  version: 6.0.2
-  resolution: "pure-rand@npm:6.0.2"
-  checksum: 10/d33f92dbac58eba65e851046905379ddd32b0af11daa49187bf2b44c4da6e5685cdcd8775388a3c706c126dcdb19bdcc0f736a0c432de25d68d21a762ff5f572
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 10/256aa4bcaf9297256f552914e03cbdb0039c8fe1db11fa1e6d3f80790e16e563eb0a859a1e61082a95e224fc0c608661839439f8ecc6a3db4e48d46d99216ee4
+  languageName: node
+  linkType: hard
+
+"queue-microtask@npm:^1.2.2":
+  version: 1.2.3
+  resolution: "queue-microtask@npm:1.2.3"
+  checksum: 10/72900df0616e473e824202113c3df6abae59150dfb73ed13273503127235320e9c8ca4aaaaccfd58cf417c6ca92a6e68ee9a5c3182886ae949a768639b388a7b
   languageName: node
   linkType: hard
 
 "react-is@npm:^18.0.0":
-  version: 18.2.0
-  resolution: "react-is@npm:18.2.0"
-  checksum: 10/200cd65bf2e0be7ba6055f647091b725a45dd2a6abef03bf2380ce701fd5edccee40b49b9d15edab7ac08a762bf83cb4081e31ec2673a5bfb549a36ba21570df
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^3.6.0":
-  version: 3.6.2
-  resolution: "readable-stream@npm:3.6.2"
-  dependencies:
-    inherits: "npm:^2.0.3"
-    string_decoder: "npm:^1.1.1"
-    util-deprecate: "npm:^1.0.1"
-  checksum: 10/d9e3e53193adcdb79d8f10f2a1f6989bd4389f5936c6f8b870e77570853561c362bee69feca2bbb7b32368ce96a85504aa4cedf7cf80f36e6a9de30d64244048
+  version: 18.3.1
+  resolution: "react-is@npm:18.3.1"
+  checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
   languageName: node
   linkType: hard
 
@@ -6258,11 +5628,11 @@ __metadata:
   linkType: hard
 
 "regenerate-unicode-properties@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "regenerate-unicode-properties@npm:10.1.0"
+  version: 10.1.1
+  resolution: "regenerate-unicode-properties@npm:10.1.1"
   dependencies:
     regenerate: "npm:^1.4.2"
-  checksum: 10/25b268659898955ad105267b4efba20e361e27b233670694b683728a2800314bec3053918d3bf71b0604376fd76fe9bc9c6f80379cfb6d1e209a58de44101aac
+  checksum: 10/b855152efdcca0ecc37ceb0cb6647a544344555fc293af3b57191b918e1bc9c95ee404a9a64a1d692bf66d45850942c29d93f2740c0d1980d3a8ea2ca63b184e
   languageName: node
   linkType: hard
 
@@ -6270,13 +5640,6 @@ __metadata:
   version: 1.4.2
   resolution: "regenerate@npm:1.4.2"
   checksum: 10/dc6c95ae4b3ba6adbd7687cafac260eee4640318c7a95239d5ce847d9b9263979758389e862fe9c93d633b5792ea4ada5708df75885dc5aa05a309fa18140a87
-  languageName: node
-  linkType: hard
-
-"regenerator-runtime@npm:^0.13.4":
-  version: 0.13.7
-  resolution: "regenerator-runtime@npm:0.13.7"
-  checksum: 10/0de0ec7b5e41038918c63e22175a9ba61068e4cc989c4b00f8cb92e6d23e5ed62b73edd2f3f3fdcb25d48d7d90d628d88bad3dce176aa5bbf10aa94a23d16a7b
   languageName: node
   linkType: hard
 
@@ -6293,6 +5656,18 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:^7.8.4"
   checksum: 10/c4fdcb46d11bbe32605b4b9ed76b21b8d3f241a45153e9dc6f5542fed4c7744fed459f42701f650d5d5956786bf7de57547329d1c05a9df2ed9e367b9d903302
+  languageName: node
+  linkType: hard
+
+"regexp.prototype.flags@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "regexp.prototype.flags@npm:1.5.2"
+  dependencies:
+    call-bind: "npm:^1.0.6"
+    define-properties: "npm:^1.2.1"
+    es-errors: "npm:^1.3.0"
+    set-function-name: "npm:^2.0.1"
+  checksum: 10/9fffc01da9c4e12670ff95bc5204364615fcc12d86fc30642765af908675678ebb0780883c874b2dbd184505fb52fa603d80073ecf69f461ce7f56b15d10be9c
   languageName: node
   linkType: hard
 
@@ -6359,22 +5734,28 @@ __metadata:
   linkType: hard
 
 "resolve@npm:^1.1.6, resolve@npm:^1.14.2, resolve@npm:^1.20.0":
-  version: 1.20.0
-  resolution: "resolve@npm:1.20.0"
+  version: 1.22.8
+  resolution: "resolve@npm:1.22.8"
   dependencies:
-    is-core-module: "npm:^2.2.0"
-    path-parse: "npm:^1.0.6"
-  checksum: 10/5a2cc3254c3f6ccc15fcfec8a47054b8b794c3318edbb3fccb116decf202b928c217e40faf33911e61681959c182e6960f7432fb2baa20ace14ebab105e08712
+    is-core-module: "npm:^2.13.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10/c473506ee01eb45cbcfefb68652ae5759e092e6b0fb64547feadf9736a6394f258fbc6f88e00c5ca36d5477fbb65388b272432a3600fa223062e54333c156753
   languageName: node
   linkType: hard
 
 "resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>":
-  version: 1.20.0
-  resolution: "resolve@patch:resolve@npm%3A1.20.0#optional!builtin<compat/resolve>::version=1.20.0&hash=c3c19d"
+  version: 1.22.8
+  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
-    is-core-module: "npm:^2.2.0"
-    path-parse: "npm:^1.0.6"
-  checksum: 10/197ca6b762f32ece2eebb55158532512b26bdb10f9e34f272347e92fb55eec691939daf974e850e9cc9cf3c692334bb9339e0f5f1065b48f3daba227fd60e06c
+    is-core-module: "npm:^2.13.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10/f345cd37f56a2c0275e3fe062517c650bb673815d885e7507566df589375d165bbbf4bdb6aa95600a9bc55f4744b81f452b5a63f95b9f10a72787dba3c90890a
   languageName: node
   linkType: hard
 
@@ -6392,35 +5773,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "rimraf@npm:3.0.2"
-  dependencies:
-    glob: "npm:^7.1.3"
-  bin:
-    rimraf: bin.js
-  checksum: 10/063ffaccaaaca2cfd0ef3beafb12d6a03dd7ff1260d752d62a6077b5dfff6ae81bea571f655bb6b589d366930ec1bdd285d40d560c0dae9b12f125e54eb743d5
-  languageName: node
-  linkType: hard
-
 "run-parallel@npm:^1.1.9":
-  version: 1.1.9
-  resolution: "run-parallel@npm:1.1.9"
-  checksum: 10/8bbeda89c2c1dbfeaa0cdb9f17e93a011ac58ef77339ef1e61a62208b67c8e7b661891df677bb7c5be84b8792e27061177368d500b3c731bb019b0c71e667591
+  version: 1.2.0
+  resolution: "run-parallel@npm:1.2.0"
+  dependencies:
+    queue-microtask: "npm:^1.2.2"
+  checksum: 10/cb4f97ad25a75ebc11a8ef4e33bb962f8af8516bb2001082ceabd8902e15b98f4b84b4f8a9b222e5d57fc3bd1379c483886ed4619367a7680dad65316993021d
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:~5.1.1":
-  version: 5.1.2
-  resolution: "safe-buffer@npm:5.1.2"
-  checksum: 10/7eb5b48f2ed9a594a4795677d5a150faa7eb54483b2318b568dc0c4fc94092a6cce5be02c7288a0500a156282f5276d5688bce7259299568d1053b2150ef374a
+"safe-array-concat@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "safe-array-concat@npm:1.1.2"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    get-intrinsic: "npm:^1.2.4"
+    has-symbols: "npm:^1.0.3"
+    isarray: "npm:^2.0.5"
+  checksum: 10/a54f8040d7cb696a1ee38d19cc71ab3cfb654b9b81bae00c6459618cfad8214ece7e6666592f9c925aafef43d0a20c5e6fbb3413a2b618e1ce9d516a2e6dcfc5
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:~5.2.0":
-  version: 5.2.1
-  resolution: "safe-buffer@npm:5.2.1"
-  checksum: 10/32872cd0ff68a3ddade7a7617b8f4c2ae8764d8b7d884c651b74457967a9e0e886267d3ecc781220629c44a865167b61c375d2da6c720c840ecd73f45d5d9451
+"safe-regex-test@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "safe-regex-test@npm:1.0.3"
+  dependencies:
+    call-bind: "npm:^1.0.6"
+    es-errors: "npm:^1.3.0"
+    is-regex: "npm:^1.1.4"
+  checksum: 10/b04de61114b10274d92e25b6de7ccb5de07f11ea15637ff636de4b5190c0f5cd8823fe586dde718504cf78055437d70fd8804976894df502fcf5a210c970afb3
   languageName: node
   linkType: hard
 
@@ -6440,16 +5821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.0.0, semver@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "semver@npm:6.3.0"
-  bin:
-    semver: ./bin/semver.js
-  checksum: 10/8dd72e7c7cdbd8cff66b5530eeff9eec2342b127eef2c956259cdf66b85addf4829e6e4a045ca30d974d075595b0b03faa6318a597307eb3984649516b98b501
-  languageName: node
-  linkType: hard
-
-"semver@npm:^6.3.1":
+"semver@npm:^6.3.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:
@@ -6458,18 +5830,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5":
-  version: 7.5.1
-  resolution: "semver@npm:7.5.1"
-  dependencies:
-    lru-cache: "npm:^6.0.0"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/01fcb5ff66fb8cb9ff54e898ac9786fbafec65f93d0df910ea9300451719b204b1c5e8007c99c1abb410eb60f84497a1f8c02b1a0e97880842b7f6075e1d82b6
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0":
+"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0":
   version: 7.6.3
   resolution: "semver@npm:7.6.3"
   bin:
@@ -6478,10 +5839,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-blocking@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "set-blocking@npm:2.0.0"
-  checksum: 10/8980ebf7ae9eb945bb036b6e283c547ee783a1ad557a82babf758a065e2fb6ea337fd82cac30dd565c1e606e423f30024a19fff7afbf4977d784720c4026a8ef
+"set-function-length@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "set-function-length@npm:1.2.2"
+  dependencies:
+    define-data-property: "npm:^1.1.4"
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+    get-intrinsic: "npm:^1.2.4"
+    gopd: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.2"
+  checksum: 10/505d62b8e088468917ca4e3f8f39d0e29f9a563b97dbebf92f4bd2c3172ccfb3c5b8e4566d5fcd00784a00433900e7cb8fbc404e2dbd8c3818ba05bb9d4a8a6d
+  languageName: node
+  linkType: hard
+
+"set-function-name@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "set-function-name@npm:2.0.2"
+  dependencies:
+    define-data-property: "npm:^1.1.4"
+    es-errors: "npm:^1.3.0"
+    functions-have-names: "npm:^1.2.3"
+    has-property-descriptors: "npm:^1.0.2"
+  checksum: 10/c7614154a53ebf8c0428a6c40a3b0b47dac30587c1a19703d1b75f003803f73cdfa6a93474a9ba678fa565ef5fbddc2fae79bca03b7d22ab5fd5163dbe571a74
   languageName: node
   linkType: hard
 
@@ -6523,6 +5903,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"side-channel@npm:^1.0.4":
+  version: 1.0.6
+  resolution: "side-channel@npm:1.0.6"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.4"
+    object-inspect: "npm:^1.13.1"
+  checksum: 10/eb10944f38cebad8ad643dd02657592fa41273ce15b8bfa928d3291aff2d30c20ff777cfe908f76ccc4551ace2d1245822fdc576657cce40e9066c638ca8fa4d
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -6530,7 +5922,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sisteransi@npm:^1.0.4":
+"signal-exit@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "signal-exit@npm:4.1.0"
+  checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
+  languageName: node
+  linkType: hard
+
+"sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
   checksum: 10/aba6438f46d2bfcef94cf112c835ab395172c75f67453fe05c340c770d3c402363018ae1ab4172a1026a90c47eaccf3af7b6ff6fa749a680c2929bd7fa2b37a4
@@ -6551,24 +5950,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "socks-proxy-agent@npm:7.0.0"
+"socks-proxy-agent@npm:^8.0.3":
+  version: 8.0.4
+  resolution: "socks-proxy-agent@npm:8.0.4"
   dependencies:
-    agent-base: "npm:^6.0.2"
-    debug: "npm:^4.3.3"
-    socks: "npm:^2.6.2"
-  checksum: 10/26c75d9c62a9ed3fd494df60e65e88da442f78e0d4bc19bfd85ac37bd2c67470d6d4bba5202e804561cda6674db52864c9e2a2266775f879bc8d89c1445a5f4c
+    agent-base: "npm:^7.1.1"
+    debug: "npm:^4.3.4"
+    socks: "npm:^2.8.3"
+  checksum: 10/c8e7c2b398338b49a0a0f4d2bae5c0602aeeca6b478b99415927b6c5db349ca258448f2c87c6958ebf83eea17d42cbc5d1af0bfecb276cac10b9658b0f07f7d7
   languageName: node
   linkType: hard
 
-"socks@npm:^2.6.2":
-  version: 2.7.1
-  resolution: "socks@npm:2.7.1"
+"socks@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "socks@npm:2.8.3"
   dependencies:
-    ip: "npm:^2.0.0"
+    ip-address: "npm:^9.0.5"
     smart-buffer: "npm:^4.2.0"
-  checksum: 10/5074f7d6a13b3155fa655191df1c7e7a48ce3234b8ccf99afa2ccb56591c195e75e8bb78486f8e9ea8168e95a29573cbaad55b2b5e195160ae4d2ea6811ba833
+  checksum: 10/ffcb622c22481dfcd7589aae71fbfd71ca34334064d181df64bf8b7feaeee19706aba4cffd1de35cc7bbaeeaa0af96be2d7f40fcbc7bc0ab69533a7ae9ffc4fb
   languageName: node
   linkType: hard
 
@@ -6583,19 +5982,12 @@ __metadata:
   linkType: hard
 
 "source-map-support@npm:^0.5.16":
-  version: 0.5.19
-  resolution: "source-map-support@npm:0.5.19"
+  version: 0.5.21
+  resolution: "source-map-support@npm:0.5.21"
   dependencies:
     buffer-from: "npm:^1.0.0"
     source-map: "npm:^0.6.0"
-  checksum: 10/5a30564f9dceef1c72101923bd05be1a0b7ec6a3afe205ca09b73133999966cb651dd0c2b9b011f78919e9488e4633929cfd5634a4a0a98a0e2f5115c1e3fe76
-  languageName: node
-  linkType: hard
-
-"source-map@npm:^0.5.0":
-  version: 0.5.7
-  resolution: "source-map@npm:0.5.7"
-  checksum: 10/9b4ac749ec5b5831cad1f8cc4c19c4298ebc7474b24a0acf293e2f040f03f8eeccb3d01f12aa0f90cf46d555c887e03912b83a042c627f419bda5152d89c5269
+  checksum: 10/8317e12d84019b31e34b86d483dd41d6f832f389f7417faf8fc5c75a66a12d9686e47f589a0554a868b8482f037e23df9d040d29387eb16fa14cb85f091ba207
   languageName: node
   linkType: hard
 
@@ -6606,6 +5998,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sprintf-js@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "sprintf-js@npm:1.1.3"
+  checksum: 10/e7587128c423f7e43cc625fe2f87e6affdf5ca51c1cc468e910d8aaca46bb44a7fbcfa552f787b1d3987f7043aeb4527d1b99559e6621e01b42b3f45e5a24cbb
+  languageName: node
+  linkType: hard
+
 "sprintf-js@npm:~1.0.2":
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
@@ -6613,35 +6012,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ssri@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "ssri@npm:9.0.1"
+"ssri@npm:^10.0.0":
+  version: 10.0.6
+  resolution: "ssri@npm:10.0.6"
   dependencies:
-    minipass: "npm:^3.1.1"
-  checksum: 10/7638a61e91432510718e9265d48d0438a17d53065e5184f1336f234ef6aa3479663942e41e97df56cda06bb24d9d0b5ef342c10685add3cac7267a82d7fa6718
+    minipass: "npm:^7.0.3"
+  checksum: 10/f92c1b3cc9bfd0a925417412d07d999935917bc87049f43ebec41074661d64cf720315661844106a77da9f8204b6d55ae29f9514e673083cae39464343af2a8b
   languageName: node
   linkType: hard
 
 "stack-utils@npm:^2.0.3":
-  version: 2.0.5
-  resolution: "stack-utils@npm:2.0.5"
+  version: 2.0.6
+  resolution: "stack-utils@npm:2.0.6"
   dependencies:
     escape-string-regexp: "npm:^2.0.0"
-  checksum: 10/a6d64e5dd24d321289ebefdff2e210ece75fdf20dbcdb702b86da1f7b730743fae3e9337adae4a5cc00d4970d748ff758387df3ea7c71c45b466c43c7359bc00
+  checksum: 10/cdc988acbc99075b4b036ac6014e5f1e9afa7e564482b687da6384eee6a1909d7eaffde85b0a17ffbe186c5247faf6c2b7544e802109f63b72c7be69b13151bb
   languageName: node
   linkType: hard
 
 "string-length@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "string-length@npm:4.0.1"
+  version: 4.0.2
+  resolution: "string-length@npm:4.0.2"
   dependencies:
     char-regex: "npm:^1.0.2"
     strip-ansi: "npm:^6.0.0"
-  checksum: 10/7bd3191668ddafa6f574a8b17a1bd1b085737d64ceefa51f72cdd19c45a730422cd70d984eee7584d6e5b5c84b6318633c6d6a720a4bfd7c58769985fa77573e
+  checksum: 10/ce85533ef5113fcb7e522bcf9e62cb33871aa99b3729cec5595f4447f660b0cefd542ca6df4150c97a677d58b0cb727a3fe09ac1de94071d05526c73579bf505
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.2.3":
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -6652,52 +6051,66 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^4.1.0, string-width@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "string-width@npm:4.2.0"
+"string-width@npm:^5.0.1, string-width@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "string-width@npm:5.1.2"
   dependencies:
-    emoji-regex: "npm:^8.0.0"
-    is-fullwidth-code-point: "npm:^3.0.0"
-    strip-ansi: "npm:^6.0.0"
-  checksum: 10/ee2c68df9a3ce4256565d2bdc8490f5706f195f88e799d3d425889264d3eff3d7984fe8b38dfc983dac948e03d8cdc737294b1c81f1528c37c9935d86b67593d
+    eastasianwidth: "npm:^0.2.0"
+    emoji-regex: "npm:^9.2.2"
+    strip-ansi: "npm:^7.0.1"
+  checksum: 10/7369deaa29f21dda9a438686154b62c2c5f661f8dda60449088f9f980196f7908fc39fdd1803e3e01541970287cf5deae336798337e9319a7055af89dafa7193
   languageName: node
   linkType: hard
 
-"string.prototype.trimend@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "string.prototype.trimend@npm:1.0.1"
+"string.prototype.trim@npm:^1.2.9":
+  version: 1.2.9
+  resolution: "string.prototype.trim@npm:1.2.9"
   dependencies:
-    define-properties: "npm:^1.1.3"
-    es-abstract: "npm:^1.17.5"
-  checksum: 10/e4e2c21f0145a6fa8c111b1bee6075d509a40702611329bcebd7ffc5cc13562cfa99636faeacccbea306d01c023dc763ce0cf38cf5d7b654705b74847b0f0e57
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.0"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 10/b2170903de6a2fb5a49bb8850052144e04b67329d49f1343cdc6a87cb24fb4e4b8ad00d3e273a399b8a3d8c32c89775d93a8f43cb42fbff303f25382079fb58a
   languageName: node
   linkType: hard
 
-"string.prototype.trimstart@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "string.prototype.trimstart@npm:1.0.1"
+"string.prototype.trimend@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "string.prototype.trimend@npm:1.0.8"
   dependencies:
-    define-properties: "npm:^1.1.3"
-    es-abstract: "npm:^1.17.5"
-  checksum: 10/0fe3cad8d597a418b058b6ec2d5c48b73172c71cb60089a0a38373eb3c2d501c4d9a00bbfad90e581c2ecf136f10f85a9dc664390e059b805dae9e4707465e0f
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 10/c2e862ae724f95771da9ea17c27559d4eeced9208b9c20f69bbfcd1b9bc92375adf8af63a103194dba17c4cc4a5cb08842d929f415ff9d89c062d44689c8761b
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.1.1":
-  version: 1.3.0
-  resolution: "string_decoder@npm:1.3.0"
+"string.prototype.trimstart@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "string.prototype.trimstart@npm:1.0.8"
   dependencies:
-    safe-buffer: "npm:~5.2.0"
-  checksum: 10/54d23f4a6acae0e93f999a585e673be9e561b65cd4cca37714af1e893ab8cd8dfa52a9e4f58f48f87b4a44918d3a9254326cb80ed194bf2e4c226e2b21767e56
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 10/160167dfbd68e6f7cb9f51a16074eebfce1571656fc31d40c3738ca9e30e35496f2c046fe57b6ad49f65f238a152be8c86fd9a2dd58682b5eba39dad995b3674
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
   dependencies:
     ansi-regex: "npm:^5.0.1"
   checksum: 10/ae3b5436d34fadeb6096367626ce987057713c566e1e7768818797e00ac5d62023d0f198c4e681eae9e20701721980b26a64a8f5b91238869592a9c6800719a2
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.0.1":
+  version: 7.1.0
+  resolution: "strip-ansi@npm:7.1.0"
+  dependencies:
+    ansi-regex: "npm:^6.0.1"
+  checksum: 10/475f53e9c44375d6e72807284024ac5d668ee1d06010740dec0b9744f2ddf47de8d7151f80e5f6190fc8f384e802fdf9504b76a7e9020c9faee7103623338be2
   languageName: node
   linkType: hard
 
@@ -6749,7 +6162,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.1.11, tar@npm:^6.1.2":
+"supports-preserve-symlinks-flag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
+  checksum: 10/a9dc19ae2220c952bd2231d08ddeecb1b0328b61e72071ff4000c8384e145cc07c1c0bdb3b5a1cb06e186a7b2790f1dee793418b332f6ddf320de25d9125be7e
+  languageName: node
+  linkType: hard
+
+"tar@npm:^6.1.11, tar@npm:^6.2.1":
   version: 6.2.1
   resolution: "tar@npm:6.2.1"
   dependencies:
@@ -6843,30 +6263,66 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "type-fest@npm:0.11.0"
-  checksum: 10/2d60de8588b876719396abdce0fcf282a0b6290259300f6334f655e99229398ea165e6cabd118961201da8ce4b87d7f50fd5628fb466c346fdc00f68f3548fec
+"type-fest@npm:^0.21.3":
+  version: 0.21.3
+  resolution: "type-fest@npm:0.21.3"
+  checksum: 10/f4254070d9c3d83a6e573bcb95173008d73474ceadbbf620dd32d273940ca18734dff39c2b2480282df9afe5d1675ebed5499a00d791758748ea81f61a38961f
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^7.17.0":
-  version: 7.17.0
-  resolution: "typescript-eslint@npm:7.17.0"
+"typed-array-buffer@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "typed-array-buffer@npm:1.0.2"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:7.17.0"
-    "@typescript-eslint/parser": "npm:7.17.0"
-    "@typescript-eslint/utils": "npm:7.17.0"
-  peerDependencies:
-    eslint: ^8.56.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/844591d50171cddc8ecb68820b541957fbabc05f30c09d758b93ea216214785fa67a08420e539feb70d542e532be88d3aa00573417dcce34ac5d1e5d57a19598
+    call-bind: "npm:^1.0.7"
+    es-errors: "npm:^1.3.0"
+    is-typed-array: "npm:^1.1.13"
+  checksum: 10/02ffc185d29c6df07968272b15d5319a1610817916ec8d4cd670ded5d1efe72901541ff2202fcc622730d8a549c76e198a2f74e312eabbfb712ed907d45cbb0b
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^7.18.0":
+"typed-array-byte-length@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "typed-array-byte-length@npm:1.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.0.1"
+    has-proto: "npm:^1.0.3"
+    is-typed-array: "npm:^1.1.13"
+  checksum: 10/e4a38329736fe6a73b52a09222d4a9e8de14caaa4ff6ad8e55217f6705b017d9815b7284c85065b3b8a7704e226ccff1372a72b78c2a5b6b71b7bf662308c903
+  languageName: node
+  linkType: hard
+
+"typed-array-byte-offset@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "typed-array-byte-offset@npm:1.0.2"
+  dependencies:
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.7"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.0.1"
+    has-proto: "npm:^1.0.3"
+    is-typed-array: "npm:^1.1.13"
+  checksum: 10/ac26d720ebb2aacbc45e231347c359e6649f52e0cfe0e76e62005912f8030d68e4cb7b725b1754e8fdd48e433cb68df5a8620a3e420ad1457d666e8b29bf9150
+  languageName: node
+  linkType: hard
+
+"typed-array-length@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "typed-array-length@npm:1.0.6"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.0.1"
+    has-proto: "npm:^1.0.3"
+    is-typed-array: "npm:^1.1.13"
+    possible-typed-array-names: "npm:^1.0.0"
+  checksum: 10/05e96cf4ff836743ebfc593d86133b8c30e83172cb5d16c56814d7bacfed57ce97e87ada9c4b2156d9aaa59f75cdef01c25bd9081c7826e0b869afbefc3e8c39
+  languageName: node
+  linkType: hard
+
+"typescript-eslint@npm:^7.17.0, typescript-eslint@npm:^7.18.0":
   version: 7.18.0
   resolution: "typescript-eslint@npm:7.18.0"
   dependencies:
@@ -6902,6 +6358,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unbox-primitive@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "unbox-primitive@npm:1.0.2"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    has-bigints: "npm:^1.0.2"
+    has-symbols: "npm:^1.0.3"
+    which-boxed-primitive: "npm:^1.0.2"
+  checksum: 10/06e1ee41c1095e37281cb71a975cb3350f7cb470a0665d2576f02cc9564f623bd90cfc0183693b8a7fdf2d242963dcc3010b509fa3ac683f540c765c0f3e7e43
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~6.11.1":
   version: 6.11.1
   resolution: "undici-types@npm:6.11.1"
@@ -6934,27 +6402,27 @@ __metadata:
   linkType: hard
 
 "unicode-property-aliases-ecmascript@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "unicode-property-aliases-ecmascript@npm:2.0.0"
-  checksum: 10/dda4d39128cbbede2ac60fbb85493d979ec65913b8a486bf7cb7a375a2346fa48cbf9dc6f1ae23376e7e8e684c2b411434891e151e865a661b40a85407db51d0
+  version: 2.1.0
+  resolution: "unicode-property-aliases-ecmascript@npm:2.1.0"
+  checksum: 10/243524431893649b62cc674d877bd64ef292d6071dd2fd01ab4d5ad26efbc104ffcd064f93f8a06b7e4ec54c172bf03f6417921a0d8c3a9994161fe1f88f815b
   languageName: node
   linkType: hard
 
-"unique-filename@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "unique-filename@npm:2.0.1"
-  dependencies:
-    unique-slug: "npm:^3.0.0"
-  checksum: 10/807acf3381aff319086b64dc7125a9a37c09c44af7620bd4f7f3247fcd5565660ac12d8b80534dcbfd067e6fe88a67e621386dd796a8af828d1337a8420a255f
-  languageName: node
-  linkType: hard
-
-"unique-slug@npm:^3.0.0":
+"unique-filename@npm:^3.0.0":
   version: 3.0.0
-  resolution: "unique-slug@npm:3.0.0"
+  resolution: "unique-filename@npm:3.0.0"
+  dependencies:
+    unique-slug: "npm:^4.0.0"
+  checksum: 10/8e2f59b356cb2e54aab14ff98a51ac6c45781d15ceaab6d4f1c2228b780193dc70fae4463ce9e1df4479cb9d3304d7c2043a3fb905bdeca71cc7e8ce27e063df
+  languageName: node
+  linkType: hard
+
+"unique-slug@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "unique-slug@npm:4.0.0"
   dependencies:
     imurmurhash: "npm:^0.1.4"
-  checksum: 10/26fc5bc209a875956dd5e84ca39b89bc3be777b112504667c35c861f9547df95afc80439358d836b878b6d91f6ee21fe5ba1a966e9ec2e9f071ddf3fd67d45ee
+  checksum: 10/40912a8963fc02fb8b600cf50197df4a275c602c60de4cac4f75879d3c48558cfac48de08a25cc10df8112161f7180b3bbb4d662aadb711568602f9eddee54f0
   languageName: node
   linkType: hard
 
@@ -6973,29 +6441,22 @@ __metadata:
   linkType: hard
 
 "uri-js@npm:^4.2.2":
-  version: 4.4.0
-  resolution: "uri-js@npm:4.4.0"
+  version: 4.4.1
+  resolution: "uri-js@npm:4.4.1"
   dependencies:
     punycode: "npm:^2.1.0"
-  checksum: 10/ef634609c6e5642c0fd54e0d4e6f01ebe956eab17f8d8fcb09b7e36055c63209e61c0d7920486430c56834fa4c9cb542932fa8dfc700adce229db69f28e0089a
-  languageName: node
-  linkType: hard
-
-"util-deprecate@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "util-deprecate@npm:1.0.2"
-  checksum: 10/474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  checksum: 10/b271ca7e3d46b7160222e3afa3e531505161c9a4e097febae9664e4b59912f4cbe94861361a4175edac3a03fee99d91e44b6a58c17a634bc5a664b19fc76fbcb
   languageName: node
   linkType: hard
 
 "v8-to-istanbul@npm:^9.0.1":
-  version: 9.1.0
-  resolution: "v8-to-istanbul@npm:9.1.0"
+  version: 9.3.0
+  resolution: "v8-to-istanbul@npm:9.3.0"
   dependencies:
     "@jridgewell/trace-mapping": "npm:^0.3.12"
     "@types/istanbul-lib-coverage": "npm:^2.0.1"
-    convert-source-map: "npm:^1.6.0"
-  checksum: 10/95811ff2f17a31432c3fc7b3027b7e8c2c6ca5e60a7811c5050ce51920ab2b80df29feb04c52235bbfdaa9a6809acd5a5dd9668292e98c708617c19e087c3f68
+    convert-source-map: "npm:^2.0.0"
+  checksum: 10/fb1d70f1176cb9dc46cabbb3fd5c52c8f3e8738b61877b6e7266029aed0870b04140e3f9f4550ac32aebcfe1d0f38b0bac57e1e8fb97d68fec82f2b416148166
   languageName: node
   linkType: hard
 
@@ -7017,7 +6478,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^2.0.1, which@npm:^2.0.2":
+"which-boxed-primitive@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "which-boxed-primitive@npm:1.0.2"
+  dependencies:
+    is-bigint: "npm:^1.0.1"
+    is-boolean-object: "npm:^1.1.0"
+    is-number-object: "npm:^1.0.4"
+    is-string: "npm:^1.0.5"
+    is-symbol: "npm:^1.0.3"
+  checksum: 10/9c7ca7855255f25ac47f4ce8b59c4cc33629e713fd7a165c9d77a2bb47bf3d9655a5664660c70337a3221cf96742f3589fae15a3a33639908d33e29aa2941efb
+  languageName: node
+  linkType: hard
+
+"which-typed-array@npm:^1.1.14, which-typed-array@npm:^1.1.15":
+  version: 1.1.15
+  resolution: "which-typed-array@npm:1.1.15"
+  dependencies:
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.7"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.0.1"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10/c3b6a99beadc971baa53c3ee5b749f2b9bdfa3b3b9a70650dd8511a48b61d877288b498d424712e9991d16019633086bd8b5923369460d93463c5825fa36c448
+  languageName: node
+  linkType: hard
+
+"which@npm:^2.0.1":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
   dependencies:
@@ -7028,16 +6515,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wide-align@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "wide-align@npm:1.1.5"
+"which@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "which@npm:4.0.0"
   dependencies:
-    string-width: "npm:^1.0.2 || 2 || 3 || 4"
-  checksum: 10/d5f8027b9a8255a493a94e4ec1b74a27bff6679d5ffe29316a3215e4712945c84ef73ca4045c7e20ae7d0c72f5f57f296e04a4928e773d4276a2f1222e4c2e99
+    isexe: "npm:^3.1.1"
+  bin:
+    node-which: bin/which.js
+  checksum: 10/f17e84c042592c21e23c8195108cff18c64050b9efb8459589116999ea9da6dd1509e6a1bac3aeebefd137be00fabbb61b5c2bc0aa0f8526f32b58ee2f545651
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^7.0.0":
+"word-wrap@npm:^1.2.5":
+  version: 1.2.5
+  resolution: "word-wrap@npm:1.2.5"
+  checksum: 10/1ec6f6089f205f83037be10d0c4b34c9183b0b63fca0834a5b3cee55dd321429d73d40bb44c8fc8471b5203d6e8f8275717f49a8ff4b2b0ab41d7e1b563e0854
+  languageName: node
+  linkType: hard
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
   dependencies:
@@ -7045,6 +6541,17 @@ __metadata:
     string-width: "npm:^4.1.0"
     strip-ansi: "npm:^6.0.0"
   checksum: 10/cebdaeca3a6880da410f75209e68cd05428580de5ad24535f22696d7d9cab134d1f8498599f344c3cf0fb37c1715807a183778d8c648d6cc0cb5ff2bb4236540
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "wrap-ansi@npm:8.1.0"
+  dependencies:
+    ansi-styles: "npm:^6.1.0"
+    string-width: "npm:^5.0.1"
+    strip-ansi: "npm:^7.0.1"
+  checksum: 10/7b1e4b35e9bb2312d2ee9ee7dc95b8cb5f8b4b5a89f7dde5543fe66c1e3715663094defa50d75454ac900bd210f702d575f15f3f17fa9ec0291806d2578d1ddf
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,6 +2124,7 @@ __metadata:
     jest: "npm:^29.7.0"
     prettier: "npm:^3.3.3"
     shelljs: "npm:^0.8.5"
+    tstyche: "npm:^2.1.1"
     typescript: "npm:~5.5.4"
     typescript-eslint: "npm:^7.18.0"
   languageName: unknown
@@ -6809,6 +6810,20 @@ __metadata:
   peerDependencies:
     typescript: ">=4.2.0"
   checksum: 10/3ee44faa24410cd649b5c864e068d438aa437ef64e9e4a66a41646a6d3024d3097a695eeb3fb26ee364705d3cb9653a65756d009e6a53badb6066a5f447bf7ed
+  languageName: node
+  linkType: hard
+
+"tstyche@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "tstyche@npm:2.1.1"
+  peerDependencies:
+    typescript: 4.x || 5.x
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tstyche: ./build/bin.js
+  checksum: 10/f30e7d782e51c262528ededf383c9daf39af8dea063d483667e3ff9f4800434891589c294c4b4f69802dd06daf8fb1d2a10553316d2f4631ba1413d3e48dab81
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Add a mini test runner to each exercise that determine if
  - it should run `tsc` (right now always yes)
  - it should run `tstyche` (only if there are type tests)
  - it should run `jest` (only if there are implementation tests)

Additionally implements the first concept exercise.