### PR TITLE
ci(dependabot): change to monthly interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
 
   # Enable version updates for npm (yarn)
   - package-ecosystem: 'npm'
@@ -13,7 +13,7 @@ updates:
     directory: '/'
     # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
 
   # Enable version updates for npm (yarn)
   - package-ecosystem: 'npm'
@@ -21,4 +21,4 @@ updates:
     directory: '/common/'
     # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: 'daily'
+      interval: 'monthly'


### PR DESCRIPTION
This PR changes the interval for dependabot updates to monthly.

Right now, the interval is usually set to daily, which results in (almost) daily notifications for Exercism maintainers, and frequent Docker updates to all tooling repos.

To reduce the maintenance burden, we are lowering the frequency to monthly. Due to Exercism's setup, it is unlikely that dependabot issues in our repositories need to be handled with any urgency, so we consider this to be a wise tradeoff.

For maintained track repos, maintainers can choose to close this PR unmerged. But for tooling repos and unmaintained tracks, we are requiring it to be merged.

Thanks!