### PR TITLE
Update resistor-color.test.ts

### DIFF
--- a/exercises/practice/resistor-color/resistor-color.test.ts
+++ b/exercises/practice/resistor-color/resistor-color.test.ts
@@ -1,17 +1,44 @@
-import { describe, xdescribe, it, expect, xit } from '@jest/globals'
+import { describe, it, expect } from '@jest/globals'
 import { colorCode, COLORS } from './resistor-color.ts'
 
 describe('color code', () => {
   it('Black', () => {
     expect(colorCode('black')).toEqual(0)
   })
-
-  xit('White', () => {
+  
+  it('White', () => {
     expect(colorCode('white')).toEqual(9)
   })
-
-  xit('Orange', () => {
+  
+  it('Orange', () => {
     expect(colorCode('orange')).toEqual(3)
   })
+  
+  it('Brown', () => {
+    expect(colorCode('brown')).toEqual(1)
+  })
+  
+  it('Red', () => {
+    expect(colorCode('red')).toEqual(2)
+  })
+  
+  it('Yellow', () => {
+    expect(colorCode('yellow')).toEqual(4)
+  })
+  
+  it('Green', () => {
+    expect(colorCode('green')).toEqual(5)
+  })
+  
+  it('Blue', () => {
+    expect(colorCode('blue')).toEqual(6)
+  })
+  
+  it('Violet', () => {
+    expect(colorCode('violet')).toEqual(7)
+  })
+  
+  it('Grey', () => {
+    expect(colorCode('grey')).toEqual(8)
+  })
 })
-


### PR DESCRIPTION
Removed assertion for the colors data structure and implemented tests for remaining colors

COLORS type should not be asserted if not explicitly typed in the template or mentioned in the docs 

By asserting the structure of the data type this prevents correct solutions from passing the test and restricts developer freedom. 

Asserting that colors is an string array makes the following data structure trigger a failure even if the colorCode method produces the correct result;
```
export const COLORS: { color: string; code: number }[] = [
  { color: "black", code: 0 },
  { color: "brown", code: 1 },
  { color: "red", code: 2 },
  { color: "orange", code: 3 },
  { color: "yellow", code: 4 },
  { color: "green", code: 5 },
  { color: "blue", code: 6 },
  { color: "violet", code: 7 },
  { color: "grey", code: 8 },
  { color: "white", code: 9 },
];
```

Asserting that COLORS is an array with strings in the exact order and skipping subsequent tests is a lazy way to identify a correct solution. 

This solution encourages developer autonomy and implements more robust testing of the solution. 