### PR TITLE
Sync `roman-numeral` tests

### DIFF
--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -84,5 +84,8 @@ description = "3000 is MMM"
 [3bc4b41c-c2e6-49d9-9142-420691504336]
 description = "3001 is MMMI"
 
+[2f89cad7-73f6-4d1b-857b-0ef531f68b7e]
+description = "3888 is MMMDCCCLXXXVIII"
+
 [4e18e96b-5fbb-43df-a91b-9cb511fe0856]
 description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/roman-numerals.test.ts
+++ b/exercises/practice/roman-numerals/roman-numerals.test.ts
@@ -27,5 +27,6 @@ describe('toRoman()', () => {
   xit('converts 1666', () => expect(toRoman(1666)).toEqual('MDCLXVI'))
   xit('converts 3000', () => expect(toRoman(3000)).toEqual('MMM'))
   xit('converts 3001', () => expect(toRoman(3001)).toEqual('MMMI'))
+  xit('converts 3888', () => expect(toRoman(3888)).toEqual('MMMDCCCLXXXVIII'))
   xit('converts 3999', () => expect(toRoman(3999)).toEqual('MMMCMXCIX'))
 })


### PR DESCRIPTION
Related to https://github.com/exercism/typescript/issues/1597. Mark as tiny.