### PR TITLE
Sync `reverse-string` tests

### DIFF
--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [c3b7d806-dced-49ee-8543-933fd1719b1c]
 description = "an empty string"
@@ -19,3 +26,16 @@ description = "a palindrome"
 
 [b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
 description = "an even-sized word"
+
+[1bed0f8a-13b0-4bd3-9d59-3d0593326fa2]
+description = "wide characters"
+
+[93d7e1b8-f60f-4f3c-9559-4056e10d2ead]
+description = "grapheme cluster with pre-combined form"
+include = false
+comment = "revisit once after upgrade to es2022 or higher"
+
+[1028b2c1-6763-4459-8540-2da47ca512d9]
+description = "grapheme clusters"
+include = false
+comment = "revisit once after upgrade to es2022 or higher"

--- a/exercises/practice/reverse-string/reverse-string.test.ts
+++ b/exercises/practice/reverse-string/reverse-string.test.ts
@@ -26,4 +26,14 @@ describe('Reverse String', () => {
     const expected = 'racecar'
     expect(reverse('racecar')).toEqual(expected)
   })
+
+  xit('an even-sized word', () => {
+    const expected = 'reward'
+    expect(reverse('drawer')).toEqual(expected)
+  })
+
+  xit('wide characters', () => {
+    const expected = '猫子'
+    expect(reverse('子猫')).toEqual(expected)
+  })
 })


### PR DESCRIPTION
Related to #1597. Mark as tiny please.

I compared the example solutions for this track and JavaScript. It seems once we've moved to ES2022+, using `Intl.Segmenter` would be viable here for adding the last two tests. However, if I don't put them in the toml file, the bot will keep alerting that they're unsynced so I tentatively set them as not included with a comment explaining it's only provisional.