### PR TITLE
Sync `knapsack` tests

### DIFF
--- a/exercises/practice/knapsack/.meta/tests.toml
+++ b/exercises/practice/knapsack/.meta/tests.toml
@@ -1,27 +1,36 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
 [a4d7d2f0-ad8a-460c-86f3-88ba709d41a7]
-description = "No items"
-include = true
+description = "no items"
+include = false
+
+[3993a824-c20e-493d-b3c9-ee8a7753ee59]
+description = "no items"
+reimplements = "a4d7d2f0-ad8a-460c-86f3-88ba709d41a7"
 
 [1d39e98c-6249-4a8b-912f-87cb12e506b0]
-description = "One item, but too heavy"
-include = true
+description = "one item, too heavy"
 
 [833ea310-6323-44f2-9d27-a278740ffbd8]
-description = "Five items. Can\'t be greedy by weight"
-include = true
+description = "five items (cannot be greedy by weight)"
 
 [277cdc52-f835-4c7d-872b-bff17bab2456]
-description = "Five items. Can\'t be greedy by value"
-include = true
+description = "five items (cannot be greedy by value)"
 
 [81d8e679-442b-4f7a-8a59-7278083916c9]
-description = "Example knapsack"
-include = true
+description = "example knapsack"
 
 [f23a2449-d67c-4c26-bf3e-cde020f27ecc]
 description = "8 items"
-include = true
 
 [7c682ae9-c385-4241-a197-d2fa02c81a11]
 description = "15 items"
-include = true


### PR DESCRIPTION
Related to https://github.com/exercism/typescript/issues/1597. Mark as tiny. The new no items test is identical to the old one except it's an empty `items` list upstream instead of an empty object.