### PR TITLE
Sync `crypto-square` tests

### DIFF
--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -1,9 +1,19 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [407c3837-9aa7-4111-ab63-ec54b58e8e9f]
 description = "empty plaintext results in an empty ciphertext"
+
+[aad04a25-b8bb-4304-888b-581bea8e0040]
+description = "normalization results in empty plaintext"
 
 [64131d65-6fd9-4f58-bdd8-4a2370fb481d]
 description = "Lowercase"
@@ -22,3 +32,8 @@ description = "8 character plaintext results in 3 chunks, the last one with a tr
 
 [fbcb0c6d-4c39-4a31-83f6-c473baa6af80]
 description = "54 character plaintext results in 7 chunks, the last two with trailing spaces"
+include = false
+
+[33fd914e-fa44-445b-8f38-ff8fbc9fe6e6]
+description = "54 character plaintext results in 8 chunks, the last two with trailing spaces"
+reimplements = "fbcb0c6d-4c39-4a31-83f6-c473baa6af80"

--- a/exercises/practice/crypto-square/crypto-square.test.ts
+++ b/exercises/practice/crypto-square/crypto-square.test.ts
@@ -7,6 +7,11 @@ describe('Crypto', () => {
     expect(crypto.ciphertext).toEqual('')
   })
 
+  xit('normalization results in empty plaintext', () => {
+    const crypto = new Crypto('... --- ...')
+    expect(crypto.ciphertext).toEqual('')
+  })
+
   xit('Lowercase', () => {
     const crypto = new Crypto('A')
     expect(crypto.ciphertext).toEqual('a')
@@ -32,7 +37,7 @@ describe('Crypto', () => {
     expect(crypto.ciphertext).toEqual('clu hlt io ')
   })
 
-  it.skip('54 character plaintext results in 7 chunks, the last two with trailing spaces', () => {
+  it.skip('54 character plaintext results in 8 chunks, the last two with trailing spaces', () => {
     const crypto = new Crypto(
       'If man was meant to stay on the ground, god would have given us roots.'
     )


### PR DESCRIPTION
Mark as tiny.