### PR TITLE
Rename `list-ops` method from `concat` to `concatenate`

### DIFF
--- a/exercises/practice/list-ops/.meta/proof.ci.ts
+++ b/exercises/practice/list-ops/.meta/proof.ci.ts
@@ -20,7 +20,7 @@ const Null: Cons<undefined> = {
   append<T>(other: Cons<T>): Cons<T> {
     return other
   },
-  concat(): Cons<undefined> {
+  concatenate(): Cons<undefined> {
     return this
   },
   forEach(): void {
@@ -71,7 +71,7 @@ class Cons<T> {
     return other.foldl((result, item) => result.push(item), this)
   }
 
-  public concat(others: Cons<Cons<T>>): Cons<T> {
+  public concatenate(others: Cons<Cons<T>>): Cons<T> {
     return others.foldl<Cons<T>>((result, other) => result.append(other), this)
   }
 

--- a/exercises/practice/list-ops/list-ops.test.ts
+++ b/exercises/practice/list-ops/list-ops.test.ts
@@ -85,11 +85,11 @@ describe('append entries to a list and return the new list', () => {
   })
 })
 
-describe('concat lists and lists of lists into new list', () => {
+describe('concatenate lists and lists of lists into new list', () => {
   xit('empty list', () => {
     const list1 = List.create()
     const list2 = List.create<ReturnType<typeof List.create>>()
-    expect(list1.concat(list2)).toHaveValues()
+    expect(list1.concatenate(list2)).toHaveValues()
   })
 
   xit('list of lists', () => {
@@ -98,7 +98,7 @@ describe('concat lists and lists of lists into new list', () => {
     const list3 = List.create<number>()
     const list4 = List.create(4, 5, 6)
     const listOfLists = List.create(list2, list3, list4)
-    expect(list1.concat(listOfLists)).toHaveValues(1, 2, 3, 4, 5, 6)
+    expect(list1.concatenate(listOfLists)).toHaveValues(1, 2, 3, 4, 5, 6)
   })
 })
 


### PR DESCRIPTION
This aligns with the name used in instructions.

See [this forum post](https://forum.exercism.org/t/align-list-ops-instructions-with-tested-method-names/35312/9) and #1634 for context.